### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# macOS
+.DS_Store
+
+# Python
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Adds a `.gitignore` scoped to this project:

- macOS `.DS_Store` (OS artifact any contributor may create)
- Python bytecode (`__pycache__/`, `*.py[cod]`) from `resolve_dependencies.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)