### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @femiwiki/reviewer


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` assigning the [@femiwiki/reviewer](https://github.com/orgs/femiwiki/teams/reviewer) team as the default reviewer for all paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)