### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
Adds `.github/dependabot.yml` to keep the GitHub Actions referenced in `action.yml` (and future workflows) up to date. Weekly schedule, grouped updates, 7-day cooldown, labelled `dependencies`/`github-actions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)