### PR TITLE
fix: correct phan docker image cache path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,7 @@ runs:
       if: inputs.stage == 'phan'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        path: /home/runner/docker-images/${{ inputs.env.phan-docker-image  }}
+        path: /home/runner/docker-images/${{ inputs.phan-docker-image }}
         key: ${{ inputs.phan-docker-image }}:${{ steps.tags.outputs.phan }}-${{ inputs.cache-key }}
 
     - if: inputs.stage == 'coverage'


### PR DESCRIPTION
The cache `path` for the phan Docker image used `inputs.env.phan-docker-image`, which is an invalid expression that always evaluated to an empty string. As a result the phan Docker image was cached under a wrong path.

This corrects the expression to `inputs.phan-docker-image` (and removes a stray double space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)