### PR TITLE
fix: iterate over EXCLUDES in known-failures exclusion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
                 # "GrowthExperiments"
               )
             fi
-            for dep in "${arr[@]}"; do
+            for dep in "${EXCLUDES[@]}"; do
               DEPENDENCIES="$(echo "$DEPENDENCIES" | grep -v /${dep}$)"
             done
           fi


### PR DESCRIPTION
## Bug

The exclude-known-failures loop in `action.yml` iterated over an undefined `arr` variable instead of the `EXCLUDES` array defined just a few lines above. Since `arr` was never set, the loop body never executed and the exclude-known-failures feature was a no-op.

## Fix

Change the loop to iterate over `EXCLUDES`, so the listed dependencies are actually excluded from the resolved dependency list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)