### PR TITLE
feat!: default mediawiki-version to REL1_45

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mediawiki-version: [REL1_43, master]
+        mediawiki-version: [REL1_45, master]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: femiwiki/quibble-action@dc8d9ec9d6c86ba9805a77736c68f974d250aa8f # v1.0.0
@@ -105,7 +105,7 @@ jobs:
 
 | Name | Default | Description |
 | --- | --- | --- |
-| `mediawiki-version` | `REL1_43` | MediaWiki branch to test against, for example `master` or `REL1_43`. |
+| `mediawiki-version` | `REL1_45` | MediaWiki branch to test against, for example `master` or `REL1_43`. |
 | `stage` | `all` | Stage to run. Any Quibble stage, or `phan` / `coverage`. |
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: mediawiki-phan-php81
 
   mediawiki-version:
-    default: REL1_43
+    default: REL1_45
   stage:
     description: All stages listed at https://doc.wikimedia.org/quibble/usage.html#stages. `phan` and `coverage` also supported.
     default: all


### PR DESCRIPTION
Bumps the default `mediawiki-version` from `REL1_43` to `REL1_45` (the `REL1_45` branch exists on gerrit `mediawiki/core`), and updates the README to match.

This is a **breaking change**: workflows that relied on the previous `REL1_43` default and did not set `mediawiki-version` explicitly will now test against `REL1_45`. To keep the old behaviour, set:

```yaml
        with:
          mediawiki-version: REL1_43
```

The `feat!` / `BREAKING CHANGE:` commit makes release-please cut a new major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)