### PR TITLE
feat: add php-version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ jobs:
 | `quibble-docker-image` | `quibble-buster-php81` | Image used for most stages. |
 | `coverage-docker-image` | `quibble-buster-php74-coverage` | Image used for the `coverage` stage. |
 | `phan-docker-image` | `mediawiki-phan-php81` | Image used for the `phan` stage. |
+| `php-version` | `8.1` | PHP version to set up for the `phan` stage. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     default: quibble-buster-php74-coverage
   phan-docker-image:
     default: mediawiki-phan-php81
+  php-version:
+    description: PHP version to set up for the `phan` stage.
+    default: '8.1'
 
   mediawiki-version:
     default: REL1_45
@@ -258,7 +261,7 @@ runs:
     - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       if: inputs.stage == 'phan'
       with:
-        php-version: '8.1'
+        php-version: ${{ inputs.php-version }}
 
     - if: inputs.stage == 'phan'
       shell: bash


### PR DESCRIPTION
Adds a `php-version` input so the PHP version set up for the `phan` stage is configurable, instead of being hardcoded to `8.1`. Defaults to `8.1`, so existing behavior is unchanged.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)