### PR TITLE
feat: select Docker images from php-version and debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ its `*-docker-image` input, which takes precedence over the derivation.
 | `coverage` | `quibble-<debian>-php<version>-coverage` | `coverage-docker-image` |
 | `phan` | `mediawiki-phan-php<version>` | `phan-docker-image` |
 
-With the defaults (`debian: buster`, `php-version: '8.1'`) these resolve to
-`quibble-buster-php81`, `quibble-buster-php74-coverage`, and
-`mediawiki-phan-php81`. The coverage image defaults to an explicit value rather
-than a derived one, because only a few coverage images are published.
+For example, `debian: buster` with `php-version: '8.1'` derives
+`quibble-buster-php81` and `mediawiki-phan-php81`. The coverage image is not
+derived by default; it falls back to its explicit `coverage-docker-image`
+default, because only a few coverage images are published.
 
 Available bases and versions are whatever the
 [Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ jobs:
 | `quibble-docker-image` | `quibble-buster-php81` | Image used for most stages. |
 | `coverage-docker-image` | `quibble-buster-php74-coverage` | Image used for the `coverage` stage. |
 | `phan-docker-image` | (derived) | Override for the phan image. Derived from `php-version` as `mediawiki-phan-php<version>` when empty. |
-| `php-version` | `8.1` | PHP version for the `phan` stage. Sets up host PHP for `composer install` and selects the phan image. |
+| `php-version` | `8.1` | PHP version for the `phan` stage. Sets up host PHP for `composer install` and selects the phan image. Supported versions are those published as a `mediawiki-phan-php<version>` image in the [Wikimedia Docker registry](https://docker-registry.wikimedia.org/). |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ jobs:
 | `docker-org` | `releng` | Registry organization. |
 | `quibble-docker-image` | `quibble-buster-php81` | Image used for most stages. |
 | `coverage-docker-image` | `quibble-buster-php74-coverage` | Image used for the `coverage` stage. |
-| `phan-docker-image` | `mediawiki-phan-php81` | Image used for the `phan` stage. |
-| `php-version` | `8.1` | PHP version to set up for the `phan` stage. |
+| `phan-docker-image` | (derived) | Override for the phan image. Derived from `php-version` as `mediawiki-phan-php<version>` when empty. |
+| `php-version` | `8.1` | PHP version for the `phan` stage. Sets up host PHP for `composer install` and selects the phan image. |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ jobs:
 
 ## Docker images
 
-Every stage runs in an official Wikimedia image pulled from
-`docker-registry`/`docker-org`. By default each image is derived from
-`php-version` (and `debian` for Quibble and coverage), so you usually only set
-those two knobs. Any image can also be pinned explicitly with its
-`*-docker-image` input, which takes precedence over the derivation.
+Every stage runs in an official Wikimedia image, pulled as
+`<docker-registry>/<docker-org>/<image>:<tag>`. By default the `<image>` is
+derived from `php-version` (and `debian` for Quibble and coverage), so you
+usually only set those two knobs. Any image can also be pinned explicitly with
+its `*-docker-image` input, which takes precedence over the derivation.
 
 | Stage | Derived image | Override input |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,37 @@ jobs:
           path: ${{ steps.quibble.outputs.coverage }}
 ```
 
+## Docker images
+
+Every stage runs in an official Wikimedia image pulled from
+`docker-registry`/`docker-org`. By default each image is derived from
+`php-version` (and `debian` for Quibble and coverage), so you usually only set
+those two knobs. Any image can also be pinned explicitly with its
+`*-docker-image` input, which takes precedence over the derivation.
+
+| Stage | Derived image | Override input |
+| --- | --- | --- |
+| Quibble (`all` and individual stages) | `quibble-<debian>-php<version>` | `quibble-docker-image` |
+| `coverage` | `quibble-<debian>-php<version>-coverage` | `coverage-docker-image` |
+| `phan` | `mediawiki-phan-php<version>` | `phan-docker-image` |
+
+With the defaults (`debian: buster`, `php-version: '8.1'`) these resolve to
+`quibble-buster-php81`, `quibble-buster-php74-coverage`, and
+`mediawiki-phan-php81`. The coverage image defaults to an explicit value rather
+than a derived one, because only a few coverage images are published.
+
+Available bases and versions are whatever the
+[Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,
+so not every `debian` / `php-version` combination exists. For example, to run
+Quibble and phan on a newer PHP:
+
+```yaml
+      - uses: femiwiki/quibble-action@dc8d9ec9d6c86ba9805a77736c68f974d250aa8f # v1.0.0
+        with:
+          debian: bullseye
+          php-version: '8.3'
+```
+
 ## Inputs
 
 | Name | Default | Description |
@@ -110,12 +141,13 @@ jobs:
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |
-| `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the Quibble images. |
+| `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
-| `quibble-docker-image` | `quibble-buster-php81` | Image used for most stages. |
-| `coverage-docker-image` | `quibble-buster-php74-coverage` | Image used for the `coverage` stage. |
-| `phan-docker-image` | (derived) | Override for the phan image. Derived from `php-version` as `mediawiki-phan-php<version>` when empty. |
-| `php-version` | `8.1` | PHP version for the `phan` stage. Sets up host PHP for `composer install` and selects the phan image. Supported versions are those published as a `mediawiki-phan-php<version>` image in the [Wikimedia Docker registry](https://docker-registry.wikimedia.org/). |
+| `debian` | `buster` | Debian base for the Quibble and coverage images. |
+| `php-version` | `8.1` | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
+| `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
+| `coverage-docker-image` | `quibble-buster-php74-coverage` | Override; `quibble-<debian>-php<version>-coverage` when empty. |
+| `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,19 @@ inputs:
     default: docker-registry.wikimedia.org
   docker-org:
     default: releng
+  debian:
+    description: Debian base for the Quibble and coverage images.
+    default: buster
   quibble-docker-image:
-    default: quibble-buster-php81
+    description: >-
+      Override for the Quibble Docker image. When empty, it is derived as
+      `quibble-<debian>-php<version>` from `debian` and `php-version`.
+    default: ""
   coverage-docker-image:
-    # There is no quibble-buster-php81-coverage yet
+    description: >-
+      Override for the coverage Docker image. When empty, it is derived as
+      `quibble-<debian>-php<version>-coverage`. Defaults to an explicit image
+      because few coverage images are published.
     default: quibble-buster-php74-coverage
   phan-docker-image:
     description: >-
@@ -18,11 +27,10 @@ inputs:
     default: ""
   php-version:
     description: >-
-      PHP version for the `phan` stage. Sets up this PHP on the host for
-      `composer install` and selects the `mediawiki-phan-php<version>` image.
-      Supported versions are those published as a `mediawiki-phan-php<version>`
-      image in the Wikimedia Docker registry
-      (https://docker-registry.wikimedia.org/).
+      PHP version. Selects the `php<version>` part of the Quibble, coverage,
+      and phan images, and sets up this PHP on the host for the `phan` stage's
+      `composer install`. Available versions depend on the images published in
+      the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
     default: '8.1'
 
   mediawiki-version:
@@ -67,21 +75,27 @@ runs:
       env:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
-        QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
-        PHAN_IMAGE_OVERRIDE: ${{ inputs.phan-docker-image }}
+        DEBIAN: ${{ inputs.debian }}
         PHP_VERSION: ${{ inputs.php-version }}
-        COVERAGE_DOCKER_IMAGE: ${{ inputs.coverage-docker-image }}
+        QUIBBLE_IMAGE_OVERRIDE: ${{ inputs.quibble-docker-image }}
+        COVERAGE_IMAGE_OVERRIDE: ${{ inputs.coverage-docker-image }}
+        PHAN_IMAGE_OVERRIDE: ${{ inputs.phan-docker-image }}
         STAGE: ${{ inputs.stage }}
       run: |
+        # Resolve the Docker images from php-version and debian, unless overridden
+        php="php${PHP_VERSION//./}"
+        QUIBBLE_DOCKER_IMAGE="${QUIBBLE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}}"
+        COVERAGE_DOCKER_IMAGE="${COVERAGE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}-coverage}"
+        PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-mediawiki-phan-${php}}"
+        echo "quibble_image=${QUIBBLE_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "coverage_image=${COVERAGE_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "phan_image=${PHAN_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
         # Get the latest docker tag
         # Ref: https://github.com/thcipriani/dockerregistry
         QUIBBLE_DOCKER_LATEST_TAG="$(curl -sL "https://${DOCKER_REGISTRY}/v2/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}/tags/list" |
           python3 -c 'import json;print("\n".join(json.loads(input())["tags"]))' |
           grep -v latest | sort -Vr | head -1)"
         echo "quibble=${QUIBBLE_DOCKER_LATEST_TAG}" >> "$GITHUB_OUTPUT"
-        # Derive the phan image from php-version unless overridden
-        PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-mediawiki-phan-php${PHP_VERSION//./}}"
-        echo "phan_image=${PHAN_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
         if [ "${STAGE}" == 'phan' ]; then
           echo "phan=$(curl -sL "https://${DOCKER_REGISTRY}/v2/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}/tags/list" |
             python3 -c 'import json;print("\n".join(json.loads(input())["tags"]))' |
@@ -131,12 +145,12 @@ runs:
     - name: Cache quibble docker image
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        path: /home/runner/docker-images/${{ inputs.quibble-docker-image }}
-        key: ${{ inputs.quibble-docker-image }}:${{ steps.tags.outputs.quibble }}-${{ inputs.cache-key }}
+        path: /home/runner/docker-images/${{ steps.tags.outputs.quibble_image }}
+        key: ${{ steps.tags.outputs.quibble_image }}:${{ steps.tags.outputs.quibble }}-${{ inputs.cache-key }}
 
     - shell: bash
       env:
-        QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
+        QUIBBLE_DOCKER_IMAGE: ${{ steps.tags.outputs.quibble_image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
         QUIBBLE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.quibble }}
@@ -152,8 +166,8 @@ runs:
       if: inputs.stage == 'coverage'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        path: /home/runner/docker-images/${{ inputs.coverage-docker-image }}
-        key: ${{ inputs.coverage-docker-image }}:${{ steps.tags.outputs.coverage }}-${{ inputs.cache-key }}
+        path: /home/runner/docker-images/${{ steps.tags.outputs.coverage_image }}
+        key: ${{ steps.tags.outputs.coverage_image }}:${{ steps.tags.outputs.coverage }}-${{ inputs.cache-key }}
 
     - name: Cache phan docker image
       if: inputs.stage == 'phan'
@@ -165,7 +179,7 @@ runs:
     - if: inputs.stage == 'coverage'
       shell: bash
       env:
-        COVERAGE_DOCKER_IMAGE: ${{ inputs.coverage-docker-image }}
+        COVERAGE_DOCKER_IMAGE: ${{ steps.tags.outputs.coverage_image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
         COVERAGE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.coverage }}
@@ -306,7 +320,7 @@ runs:
         EXTENSION_NAME: ${{ steps.setup.outputs.name }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
-        QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
+        QUIBBLE_DOCKER_IMAGE: ${{ steps.tags.outputs.quibble_image }}
         QUIBBLE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.quibble }}
         DEPENDENCIES: ${{ steps.deps.outputs.dependencies }}
       run: |
@@ -350,7 +364,7 @@ runs:
         EXTENSION_NAME: ${{ steps.setup.outputs.name }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
-        COVERAGE_DOCKER_IMAGE: ${{ inputs.coverage-docker-image }}
+        COVERAGE_DOCKER_IMAGE: ${{ steps.tags.outputs.coverage_image }}
         COVERAGE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.coverage }}
       run: |
         # Coverage
@@ -383,7 +397,7 @@ runs:
         EXTENSION_NAME: ${{ steps.setup.outputs.name }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
-        QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
+        QUIBBLE_DOCKER_IMAGE: ${{ steps.tags.outputs.quibble_image }}
         QUIBBLE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.quibble }}
         STAGE: ${{ inputs.stage }}
         DEPENDENCIES: ${{ steps.deps.outputs.dependencies }}
@@ -406,9 +420,9 @@ runs:
         EXTENSION_NAME: ${{ steps.setup.outputs.name }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
-        QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
+        QUIBBLE_DOCKER_IMAGE: ${{ steps.tags.outputs.quibble_image }}
         PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
-        COVERAGE_DOCKER_IMAGE: ${{ inputs.coverage-docker-image }}
+        COVERAGE_DOCKER_IMAGE: ${{ steps.tags.outputs.coverage_image }}
         QUIBBLE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.quibble }}
         PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
         COVERAGE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.coverage }}

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,14 @@ inputs:
     # There is no quibble-buster-php81-coverage yet
     default: quibble-buster-php74-coverage
   phan-docker-image:
-    default: mediawiki-phan-php81
+    description: >-
+      Override for the phan Docker image. When empty, it is derived from
+      `php-version` as `mediawiki-phan-php<version>`.
+    default: ""
   php-version:
-    description: PHP version to set up for the `phan` stage.
+    description: >-
+      PHP version for the `phan` stage. Sets up this PHP on the host for
+      `composer install` and selects the `mediawiki-phan-php<version>` image.
     default: '8.1'
 
   mediawiki-version:
@@ -60,7 +65,8 @@ runs:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
         QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
-        PHAN_DOCKER_IMAGE: ${{ inputs.phan-docker-image }}
+        PHAN_IMAGE_OVERRIDE: ${{ inputs.phan-docker-image }}
+        PHP_VERSION: ${{ inputs.php-version }}
         COVERAGE_DOCKER_IMAGE: ${{ inputs.coverage-docker-image }}
         STAGE: ${{ inputs.stage }}
       run: |
@@ -70,6 +76,9 @@ runs:
           python3 -c 'import json;print("\n".join(json.loads(input())["tags"]))' |
           grep -v latest | sort -Vr | head -1)"
         echo "quibble=${QUIBBLE_DOCKER_LATEST_TAG}" >> "$GITHUB_OUTPUT"
+        # Derive the phan image from php-version unless overridden
+        PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-mediawiki-phan-php${PHP_VERSION//./}}"
+        echo "phan_image=${PHAN_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
         if [ "${STAGE}" == 'phan' ]; then
           echo "phan=$(curl -sL "https://${DOCKER_REGISTRY}/v2/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}/tags/list" |
             python3 -c 'import json;print("\n".join(json.loads(input())["tags"]))' |
@@ -147,8 +156,8 @@ runs:
       if: inputs.stage == 'phan'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        path: /home/runner/docker-images/${{ inputs.phan-docker-image }}
-        key: ${{ inputs.phan-docker-image }}:${{ steps.tags.outputs.phan }}-${{ inputs.cache-key }}
+        path: /home/runner/docker-images/${{ steps.tags.outputs.phan_image }}
+        key: ${{ steps.tags.outputs.phan_image }}:${{ steps.tags.outputs.phan }}-${{ inputs.cache-key }}
 
     - if: inputs.stage == 'coverage'
       shell: bash
@@ -168,7 +177,7 @@ runs:
     - if: inputs.stage == 'phan'
       shell: bash
       env:
-        PHAN_DOCKER_IMAGE: ${{ inputs.phan-docker-image }}
+        PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
         PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
@@ -319,7 +328,7 @@ runs:
         EXTENSION_NAME: ${{ steps.setup.outputs.name }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
-        PHAN_DOCKER_IMAGE: ${{ inputs.phan-docker-image }}
+        PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
         PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
       run: |
         # Phan
@@ -395,7 +404,7 @@ runs:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
         QUIBBLE_DOCKER_IMAGE: ${{ inputs.quibble-docker-image }}
-        PHAN_DOCKER_IMAGE: ${{ inputs.phan-docker-image }}
+        PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
         COVERAGE_DOCKER_IMAGE: ${{ inputs.coverage-docker-image }}
         QUIBBLE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.quibble }}
         PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: >-
       PHP version for the `phan` stage. Sets up this PHP on the host for
       `composer install` and selects the `mediawiki-phan-php<version>` image.
+      Supported versions are those published as a `mediawiki-phan-php<version>`
+      image in the Wikimedia Docker registry
+      (https://docker-registry.wikimedia.org/).
     default: '8.1'
 
   mediawiki-version:


### PR DESCRIPTION
Makes the Wikimedia Docker images for every stage follow two simple knobs, `php-version` and `debian`, instead of hardcoded image names.

Phan analysis runs inside the phan image, and Quibble/coverage stages run inside their images, so the image name is what actually determines the PHP each stage uses. This derives them all (computed once in the `tags` step):

| Stage | Derived image | Override |
| --- | --- | --- |
| Quibble | `quibble-<debian>-php<version>` | `quibble-docker-image` |
| coverage | `quibble-<debian>-php<version>-coverage` | `coverage-docker-image` |
| phan | `mediawiki-phan-php<version>` | `phan-docker-image` |

- New `debian` input (default `buster`).
- `php-version` is now the single PHP knob (image `php<version>` part + host PHP for phan's composer install).
- Each `*-docker-image` stays as an explicit override (takes precedence when set).
- `coverage-docker-image` keeps an explicit default (`quibble-buster-php74-coverage`) because few coverage images are published, so coverage derivation is opt-in.

At the defaults (`buster`, `8.1`) every image resolves to its previous value, so this is **non-breaking**. Verified the derivation for defaults, `debian: bullseye` (where `quibble-bullseye-php81-coverage` also exists), `php-version: '8.4'`, and explicit overrides. zizmor and YAML pass. README gains a `Docker images` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)