### PR TITLE
feat!: default php-version to 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Quibble and phan on a newer PHP:
 ```yaml
       - uses: femiwiki/quibble-action@dc8d9ec9d6c86ba9805a77736c68f974d250aa8f # v1.0.0
         with:
-          debian: bullseye
-          php-version: '8.3'
+          debian: bookworm
+          php-version: '8.4'
 ```
 
 ## Inputs
@@ -144,7 +144,7 @@ Quibble and phan on a newer PHP:
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
 | `debian` | `buster` | Debian base for the Quibble and coverage images. |
-| `php-version` | `8.1` | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
+| `php-version` | `8.3` | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-buster-php74-coverage` | Override; `quibble-<debian>-php<version>-coverage` when empty. |
 | `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
       and phan images, and sets up this PHP on the host for the `phan` stage's
       `composer install`. Available versions depend on the images published in
       the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
-    default: '8.1'
+    default: '8.3'
 
   mediawiki-version:
     default: REL1_45


### PR DESCRIPTION
Bumps the default `php-version` from `8.1` to `8.3`.

With the default `debian: buster`, this selects `quibble-buster-php83` and `mediawiki-phan-php83`, both published in the Wikimedia registry. `debian` stays `buster` because that is enough for 8.3 (buster publishes php74/81/82/83 images; php84 would need `bookworm`).

This is a **breaking change**: the Quibble and phan stages now run on PHP 8.3 by default. To keep the old behavior:

```yaml
        with:
          php-version: '8.1'
```

The `coverage` stage is unaffected (it keeps its explicit `coverage-docker-image` default). 8.4 is the registry ceiling for phan, but it would also require `debian: bookworm` for Quibble, so 8.3 is the focused bump here.

The `feat!` / `BREAKING CHANGE:` commit makes release-please cut a new major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)