### PR TITLE
feat!: default to PHP 8.4 on Debian bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ default, because only a few coverage images are published.
 
 Available bases and versions are whatever the
 [Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,
-so not every `debian` / `php-version` combination exists. For example, to run
-Quibble and phan on a newer PHP:
+so not every `debian` / `php-version` combination exists. For example, to pin an
+older PHP, such as when testing an older MediaWiki branch:
 
 ```yaml
       - uses: femiwiki/quibble-action@dc8d9ec9d6c86ba9805a77736c68f974d250aa8f # v1.0.0
         with:
-          debian: bullseye
+          debian: buster
           php-version: '8.3'
 ```
 
@@ -143,8 +143,8 @@ Quibble and phan on a newer PHP:
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
-| `debian` | `buster` | Debian base for the Quibble and coverage images. |
-| `php-version` | `8.1` | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
+| `debian` | `bookworm` | Debian base for the Quibble and coverage images. |
+| `php-version` | `8.4` | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-buster-php74-coverage` | Override; `quibble-<debian>-php<version>-coverage` when empty. |
 | `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: releng
   debian:
     description: Debian base for the Quibble and coverage images.
-    default: buster
+    default: bookworm
   quibble-docker-image:
     description: >-
       Override for the Quibble Docker image. When empty, it is derived as
@@ -31,7 +31,7 @@ inputs:
       and phan images, and sets up this PHP on the host for the `phan` stage's
       `composer install`. Available versions depend on the images published in
       the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
-    default: '8.1'
+    default: '8.4'
 
   mediawiki-version:
     default: REL1_45


### PR DESCRIPTION
Bumps the defaults to the highest PHP that MediaWiki 1.45 (the default `mediawiki-version`) **officially supports** and that has Wikimedia images for both stages.

- `php-version`: `8.1` → `8.4`
- `debian`: `buster` → `bookworm`

Why 8.4:

- MediaWiki 1.45 officially supports PHP **8.2 – 8.5** (1.44: 8.1–8.4, 1.43: 8.0–8.3).
- The phan image ceiling is **8.4** (`mediawiki-phan-php85` is not published), and `php-version` drives both the Quibble and phan images, so 8.5 is not usable even though 1.45 supports it.
- 8.4 needs the `bookworm` base, because buster publishes no `quibble-buster-php84` image (`quibble-bookworm-php84` and `mediawiki-phan-php84` both exist).
- The previous default `8.1` was actually **below** 1.45's official minimum (8.2).

This is a **breaking change**: the Quibble and phan stages now run on PHP 8.4 (Debian bookworm) by default. To keep the old behavior, set `php-version: '8.1'` (and `debian: buster`). The `coverage` stage is unaffected (it keeps its explicit `coverage-docker-image` default).

Supersedes #27. The `feat!` / `BREAKING CHANGE:` commit makes release-please cut a new major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)