### PR TITLE
feat: upload Quibble logs as an artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,21 +101,6 @@ jobs:
           path: ${{ steps.quibble.outputs.coverage }}
 ```
 
-### Logs
-
-Set `upload-logs: true` to upload Quibble's logs and artifacts after the run
-(including on failure), so you can download them from the workflow run page. It
-is off by default. Before enabling, consider that the artifact:
-
-- uses storage, which is billable on private repositories;
-- is kept for the repository's retention period (90 days by default);
-- can be downloaded by anyone who can view the workflow run, so make sure the
-  logs do not expose sensitive data.
-
-The artifact is named by `log-artifact-name` (default `quibble-logs`); set a
-unique name per job when running a matrix, since artifact names must be unique
-within a workflow run.
-
 ## Docker images
 
 Every stage runs in an official Wikimedia image, pulled as
@@ -156,7 +141,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |
-| `upload-logs` | `false` | Upload Quibble's logs as an artifact (opt-in). See [Logs](#logs) for what to consider before enabling. |
+| `upload-logs` | `false` | Upload Quibble's logs as an artifact (opt-in, captured on failure too). Mind storage cost, retention, and that the artifact is downloadable by anyone who can view the run. |
 | `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |

--- a/README.md
+++ b/README.md
@@ -105,10 +105,16 @@ jobs:
 
 Set `upload-logs: true` to upload Quibble's logs and artifacts after the run
 (including on failure), so you can download them from the workflow run page. It
-is off by default, because artifact storage can incur costs on private
-repositories. The artifact is named by `log-artifact-name` (default
-`quibble-logs`); set a unique name per job when running a matrix, since artifact
-names must be unique within a workflow run.
+is off by default. Before enabling, consider that the artifact:
+
+- uses storage, which is billable on private repositories;
+- is kept for the repository's retention period (90 days by default);
+- can be downloaded by anyone who can view the workflow run, so make sure the
+  logs do not expose sensitive data.
+
+The artifact is named by `log-artifact-name` (default `quibble-logs`); set a
+unique name per job when running a matrix, since artifact names must be unique
+within a workflow run.
 
 ## Docker images
 
@@ -150,7 +156,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |
-| `upload-logs` | `false` | Upload Quibble's logs as an artifact (opt-in; storage may cost on private repos). |
+| `upload-logs` | `false` | Upload Quibble's logs as an artifact (opt-in). See [Logs](#logs) for what to consider before enabling. |
 | `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ jobs:
           path: ${{ steps.quibble.outputs.coverage }}
 ```
 
+### Logs
+
+Quibble's logs and artifacts are uploaded as an artifact after every run,
+including failures, so you can download them from the workflow run page. The
+artifact is named by `log-artifact-name` (default `quibble-logs`); set a unique
+name per job when running a matrix, since artifact names must be unique within a
+workflow run.
+
 ## Docker images
 
 Every stage runs in an official Wikimedia image, pulled as
@@ -141,6 +149,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |
+| `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
 | `debian` | `bookworm` | Debian base for the Quibble and coverage images. |

--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ jobs:
 
 ### Logs
 
-Quibble's logs and artifacts are uploaded as an artifact after every run,
-including failures, so you can download them from the workflow run page. The
-artifact is named by `log-artifact-name` (default `quibble-logs`); set a unique
-name per job when running a matrix, since artifact names must be unique within a
-workflow run.
+Set `upload-logs: true` to upload Quibble's logs and artifacts after the run
+(including on failure), so you can download them from the workflow run page. It
+is off by default, because artifact storage can incur costs on private
+repositories. The artifact is named by `log-artifact-name` (default
+`quibble-logs`); set a unique name per job when running a matrix, since artifact
+names must be unique within a workflow run.
 
 ## Docker images
 
@@ -149,6 +150,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |
+| `upload-logs` | `false` | Upload Quibble's logs as an artifact (opt-in; storage may cost on private repos). |
 | `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,12 @@ inputs:
     default: ""
   cache-key:
     default: true
+  log-artifact-name:
+    description: >-
+      Name for the artifact that Quibble's logs are uploaded under. Use a unique
+      name per job when running a matrix, since artifact names must be unique
+      within a workflow run.
+    default: quibble-logs
 outputs:
   coverage:
     value: /home/runner/cover
@@ -305,9 +311,9 @@ runs:
         # Prepare directories
         cd /home/runner
         # Move our repository
-        mkdir -p cache cover src/skins src/extensions
+        mkdir -p cache cover log src/skins src/extensions
         sudo cp -r "${GITHUB_WORKSPACE}" "src/${TYPE}s/${EXTENSION_NAME}"
-        chmod 777 src cache cover
+        chmod 777 src cache cover log
         # https://github.com/femiwiki/.github/issues/3
         sudo chown -R nobody:nogroup src cache
         sudo chown $(id -u):$(id -g) src cache
@@ -382,6 +388,7 @@ runs:
               -v "$(pwd)"/cache:/cache \
               -v "$(pwd)"/src:/workspace/src \
               -v "$(pwd)"/cover:/workspace/cover \
+              -v "$(pwd)"/log:/workspace/log \
               "${DOCKER_REGISTRY}/${DOCKER_ORG}/${COVERAGE_DOCKER_IMAGE}:${COVERAGE_DOCKER_LATEST_TAG}" \
               --skip-zuul \
               --skip-deps \
@@ -408,11 +415,20 @@ runs:
           -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \
           -v "$(pwd)"/cache:/cache \
           -v "$(pwd)"/src:/workspace/src \
+          -v "$(pwd)"/log:/workspace/log \
           "${DOCKER_REGISTRY}/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}:${QUIBBLE_DOCKER_LATEST_TAG}" \
           --skip-zuul \
           --packages-source composer \
           --run "${STAGE}" \
           $DEPENDENCIES
+
+    - name: Upload Quibble logs
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.log-artifact-name }}
+        path: /home/runner/log
+        if-no-files-found: ignore
 
     - shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,12 @@ inputs:
     default: ""
   cache-key:
     default: true
+  upload-logs:
+    description: >-
+      Upload Quibble's logs as an artifact after the run (including on failure).
+      Off by default, because artifact storage can incur costs on private
+      repositories.
+    default: false
   log-artifact-name:
     description: >-
       Name for the artifact that Quibble's logs are uploaded under. Use a unique
@@ -423,7 +429,7 @@ runs:
           $DEPENDENCIES
 
     - name: Upload Quibble logs
-      if: always()
+      if: always() && inputs.upload-logs == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.log-artifact-name }}

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,10 @@ inputs:
   upload-logs:
     description: >-
       Upload Quibble's logs as an artifact after the run (including on failure).
-      Off by default, because artifact storage can incur costs on private
-      repositories.
+      Off by default. Before enabling, consider that the artifact uses storage
+      (billable on private repositories), is kept for the repository's retention
+      period, and is downloadable by anyone who can view the run, so it should
+      not contain sensitive data.
     default: false
   log-artifact-name:
     description: >-


### PR DESCRIPTION
Quibble writes its logs and artifacts to `$WORKSPACE/log` (its `--log-dir` default is `log`, relative to the workspace). The action only mounted `src` and `cache`, so `/workspace/log` stayed inside the container and was lost on exit.

This:

- creates a host `log` directory and mounts it (`-v .../log:/workspace/log`) into the Quibble and coverage `docker run`s;
- adds an **opt-in** `upload-logs` input (default `false`) that uploads the logs with `actions/upload-artifact`. It is off by default because artifact storage can incur costs on private repositories;
- uses `if: always() && inputs.upload-logs == 'true'`, so when enabled the logs are captured even on failure (the main reason you want them);
- adds a `log-artifact-name` input (default `quibble-logs`) so matrix jobs can give the artifact a unique name;
- uses `if-no-files-found: ignore` so stages without logs (e.g. `phan`) don't error.

zizmor and YAML checks pass. Quibble's log path confirmed in `quibble/cmd.py` (`log_dir = os.path.join(workspace, args.log_dir)`, default `log`).

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)