### PR TITLE
feat: default api-testing to the wikidiff2 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ For example, `debian: buster` with `php-version: '8.1'` derives
 derived by default; it falls back to its explicit `coverage-docker-image`
 default, because only a few coverage images are published.
 
+`php-version` defaults to `8.4`, except for the `api-testing` stage, which
+defaults to `8.3`. That stage requires the wikidiff2 PHP extension, and the only
+published Quibble image that bundles it is `quibble-bookworm-php83`. Setting
+`php-version` (or `quibble-docker-image`) explicitly overrides this, but
+api-testing will fail on an image without wikidiff2.
+
 Available bases and versions are whatever the
 [Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,
 so not every `debian` / `php-version` combination exists. For example, to pin an
@@ -146,7 +152,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
 | `debian` | `bookworm` | Debian base for the Quibble and coverage images. |
-| `php-version` | `8.4` | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
+| `php-version` | `8.4` (`8.3` for `api-testing`) | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-buster-php74-coverage` | Override; `quibble-<debian>-php<version>-coverage` when empty. |
 | `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,9 @@ inputs:
       and phan images, and sets up this PHP on the host for the `phan` stage's
       `composer install`. Available versions depend on the images published in
       the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
-    default: '8.4'
+      When empty it is derived: `8.3` for the `api-testing` stage (the only
+      image bundling wikidiff2, which that stage requires), `8.4` otherwise.
+    default: ""
 
   mediawiki-version:
     default: REL1_45
@@ -96,8 +98,18 @@ runs:
         PHAN_IMAGE_OVERRIDE: ${{ inputs.phan-docker-image }}
         STAGE: ${{ inputs.stage }}
       run: |
+        # Resolve the effective PHP version, unless overridden.
+        # api-testing needs wikidiff2, bundled only in quibble-bookworm-php83.
+        if [ -n "${PHP_VERSION}" ]; then
+          php_version="${PHP_VERSION}"
+        elif [ "${STAGE}" == 'api-testing' ]; then
+          php_version='8.3'
+        else
+          php_version='8.4'
+        fi
+        echo "php_version=${php_version}" >> "$GITHUB_OUTPUT"
         # Resolve the Docker images from php-version and debian, unless overridden
-        php="php${PHP_VERSION//./}"
+        php="php${php_version//./}"
         QUIBBLE_DOCKER_IMAGE="${QUIBBLE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}}"
         COVERAGE_DOCKER_IMAGE="${COVERAGE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}-coverage}"
         PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-mediawiki-phan-${php}}"
@@ -301,7 +313,7 @@ runs:
     - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       if: inputs.stage == 'phan'
       with:
-        php-version: ${{ inputs.php-version }}
+        php-version: ${{ steps.tags.outputs.php_version }}
 
     - if: inputs.stage == 'phan'
       shell: bash


### PR DESCRIPTION
Fixes #3 (the `api-testing` stage failing with `This endpoint requires wikidiff2`).

### Background

`api-testing` is a normal Quibble stage, but MediaWiki's compare/diff REST endpoints need the **wikidiff2** PHP extension. Tracing the Wikimedia `integration/config` history (commit `34c8b6e08`, Bug T236333) and the current dockerfiles shows wikidiff2 was never a separate "api-testing image"; it is added to the **standard** Quibble image of the day. Today the only published Quibble image that bundles it is **`quibble-bookworm-php83`** (php81/82/84/85 lack it, since no `php8.4`/`php8.5` wikidiff2 package exists yet).

### Change

Apply the same derive + override pattern we use for images to `php-version`:

- When `php-version` is empty (the new default), it derives per stage: **`8.3` for `api-testing`**, `8.4` otherwise.
- So `api-testing` resolves to `quibble-bookworm-php83` (wikidiff2) by default, while every other stage stays on `8.4` as before.
- Setting `php-version` (or `quibble-docker-image`) explicitly **overrides** the derivation, exactly like the image inputs.
- The effective version is exposed as a `tags` step output and reused for the phan host `setup-php`, so there is a single source of truth.

Non-breaking: with no `php-version` set, non-api stages still resolve to `8.4`. Documented in the existing `Docker images` section and the inputs table. zizmor and YAML pass; derivation verified for empty/explicit php-version across stages.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)