### PR TITLE
ci: add a workflow that runs the action end-to-end

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+---
+name: Test
+on:
+  push:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  quibble:
+    name: phpunit-unit on BoilerPlate
+    runs-on: ubuntu-latest
+    steps:
+      # The action treats the workspace root as the extension/skin under test, so
+      # check out a real minimal extension (BoilerPlate) there, and the action
+      # under test into a subdirectory referenced via `uses: ./_action`.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: wikimedia/mediawiki-extensions-BoilerPlate
+          ref: REL1_45
+          persist-credentials: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          path: _action
+          persist-credentials: false
+      - uses: ./_action
+        with:
+          stage: phpunit-unit
+          mediawiki-version: REL1_45


### PR DESCRIPTION
## What

Adds `.github/workflows/test.yaml`, which runs the action end-to-end on a real runner against the minimal Wikimedia **BoilerPlate** extension (`phpunit-unit`, `REL1_45`).

## How

The action treats the workspace root as the extension/skin under test, so:
- **BoilerPlate** is checked out at the workspace root.
- The **action under test** is checked out into `_action` and referenced via `uses: ./_action`.

This exercises the full path plumbing: caches, the MediaWiki checkout, docker volume mounts, and teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)