### PR TITLE
fix: make Quibble logs readable before uploading them

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,3 +26,4 @@ jobs:
         with:
           stage: phpunit-unit
           mediawiki-version: REL1_45
+          upload-logs: true

--- a/action.yml
+++ b/action.yml
@@ -451,6 +451,19 @@ runs:
           --run "${STAGE}" \
           $DEPENDENCIES
 
+    - name: Make Quibble logs readable
+      if: always() && inputs.upload-logs == 'true'
+      shell: bash
+      env:
+        BASE_DIR: ${{ steps.setup.outputs.dir }}
+      run: |
+        # Quibble runs in Docker as root, so some logs (for example
+        # mysql-error.log) land root-owned and unreadable by the runner user,
+        # which fails the upload step. Make the log tree readable first.
+        if [ -d "$BASE_DIR/log" ]; then
+          sudo chmod -R a+rX "$BASE_DIR/log"
+        fi
+
     - name: Upload Quibble logs
       if: always() && inputs.upload-logs == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## What

Fixes the `upload-logs` feature, which currently fails whenever Quibble writes a root-owned log file.

## Root cause

Quibble runs in Docker as root. Some files it writes into the mounted log directory (for example `mysql-error.log`) are root-owned and unreadable by the runner user. `actions/upload-artifact` then fails while zipping:

```
Error: EACCES: permission denied, open '.../log/mysql-error.log'
```

The "Prepare directories" step already `chmod 777`s the `log` directory itself, but that does not affect the permissions of files the container later writes inside it. This was surfaced by the new end-to-end test in #32.

## Fix

Add a step that makes the log tree readable (`sudo chmod -R a+rX`) right before the upload, and re-enable `upload-logs: true` in the end-to-end test so CI actually exercises the upload path.

## Stacking

Based on #31 (`use-runner-temp`) so it stays consistent with the `RUNNER_TEMP` base directory. **Merge #31 first**, then retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)