### PR TITLE
feat: add project-path input for the project under test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,20 +10,21 @@ jobs:
     name: phpunit-unit on BoilerPlate
     runs-on: ubuntu-latest
     steps:
-      # The action treats the workspace root as the extension/skin under test, so
-      # check out a real minimal extension (BoilerPlate) there, and the action
-      # under test into a subdirectory referenced via `uses: ./_action`.
+      # Check the action out at the workspace root so it can be used as `uses: ./`,
+      # and the real minimal extension under test (BoilerPlate) into a subdirectory
+      # pointed at by the action's `project-path` input.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: wikimedia/mediawiki-extensions-BoilerPlate
           ref: REL1_45
+          path: project
           persist-credentials: false
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          path: _action
-          persist-credentials: false
-      - uses: ./_action
+      - uses: ./
         with:
           stage: phpunit-unit
           mediawiki-version: REL1_45
+          project-path: project
           upload-logs: true

--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ jobs:
           mediawiki-version: ${{ matrix.mediawiki-version }}
 ```
 
+### Testing from the same repository
+
+By default the action treats the workspace root as the project under test, so a
+consumer just checks out their repository and runs the action. When the action
+itself lives at the workspace root, for example to test it as `uses: ./`, check
+the project under test out into a subdirectory and point `project-path` at it:
+
+```yaml
+      # The action under test at the workspace root, so it can be `uses: ./`.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # The extension or skin under test in a subdirectory.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: my-org/MyExtension
+          path: project
+      - uses: ./
+        with:
+          project-path: project
+```
+
 ### Publishing coverage
 
 ```yaml
@@ -144,6 +164,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | --- | --- | --- |
 | `mediawiki-version` | `REL1_45` | MediaWiki branch to test against, for example `master` or `REL1_43`. |
 | `stage` | `all` | Stage to run. Any Quibble stage, or `phan` / `coverage`. |
+| `project-path` | `.` | Path to the extension or skin under test, relative to the workspace. Set it when the action is checked out at the workspace root (so it can be used as `uses: ./`) and the project is in a subdirectory. See [Testing from the same repository](#testing-from-the-same-repository). |
 | `exclude-known-failures` | `true` | Skip dependencies that are known to fail. |
 | `exclude-dependencies` | (none) | Space-separated list of dependency names to skip. |
 | `cache-key` | `true` | Mixed into every cache key; change it to bust the caches. |

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,13 @@ inputs:
       image bundling wikidiff2, which that stage requires), `8.4` otherwise.
     default: ""
 
+  project-path:
+    description: >-
+      Path to the extension or skin under test, relative to the workspace.
+      Defaults to the workspace root. Set this when the action itself is checked
+      out at the workspace root (so it can be referenced as `uses: ./`) and the
+      project under test is checked out into a subdirectory.
+    default: "."
   mediawiki-version:
     default: REL1_45
   stage:
@@ -70,15 +77,20 @@ runs:
     # $RUNNER_TEMP/src/                                 Mediawiki installation
     # $RUNNER_TEMP/src/<TYPE>s/<EXTENSION_NAME>/        Clone of the extension repository
     # $RUNNER_TEMP/docker-images/                       Docker images which exported with docker-save command
-    # $GITHUB_WORKSPACE/.github/workflows/dependencies  Dependency extensions and skins
+    # <path>/.github/workflows/dependencies            Dependency extensions and skins
     - id: setup
       shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.project-path }}
       run: |
         # Set up
         # Base directory for all scratch dirs. RUNNER_TEMP avoids hardcoding the
         # home path, which is not portable to self-hosted, container, or non-Linux
         # runners, and is emptied at the start of each job.
         echo "dir=$RUNNER_TEMP" >> "$GITHUB_OUTPUT"
+        # The project under test lives at inputs.project-path, which may be a
+        # subdirectory when the action is checked out at the workspace root.
+        cd "$PROJECT_PATH"
         if [ -e extension.json ]; then
           echo "type=extension" >> "$GITHUB_OUTPUT"
           echo "name=$(jq -r .name extension.json)" >> "$GITHUB_OUTPUT"
@@ -142,8 +154,10 @@ runs:
         EXCLUDE_KNOWN_FAILURES: ${{ inputs.exclude-known-failures }}
         MEDIAWIKI_VERSION: ${{ inputs.mediawiki-version }}
         EXCLUDE_DEPENDENCIES: ${{ inputs.exclude-dependencies }}
+        PROJECT_PATH: ${{ inputs.project-path }}
       run: |
         # Resolve dependencies
+        cd "$PROJECT_PATH"
         if [ -e .github/workflows/dependencies ]; then
           cd .github/workflows
           curl -sLO https://raw.githubusercontent.com/wikimedia/integration-config/master/zuul/dependencies.yaml
@@ -243,7 +257,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.setup.outputs.dir }}/src
-        key: ${{ runner.os }}-${{ inputs.mediawiki-version }}-${{ hashFiles('.github/workflows/dependencies') }}-${{ inputs.exclude-dependencies }}-${{ inputs.cache-key }}
+        key: ${{ runner.os }}-${{ inputs.mediawiki-version }}-${{ hashFiles(format('{0}/.github/workflows/dependencies', inputs.project-path)) }}-${{ inputs.exclude-dependencies }}-${{ inputs.cache-key }}
 
     - shell: bash
       env:
@@ -325,10 +339,13 @@ runs:
 
     - if: inputs.stage == 'phan'
       shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.project-path }}
       run: |
         # Composer install
+        cd "$PROJECT_PATH"
         if [ -e composer.json ]; then
-          composer install --prefer-dist --no-progress --no-interaction # $GITHUB_WORKSPACE
+          composer install --prefer-dist --no-progress --no-interaction
         fi
 
     - shell: bash
@@ -336,12 +353,15 @@ runs:
         BASE_DIR: ${{ steps.setup.outputs.dir }}
         TYPE: ${{ steps.setup.outputs.type }}
         EXTENSION_NAME: ${{ steps.setup.outputs.name }}
+        PROJECT_PATH: ${{ inputs.project-path }}
       run: |
         # Prepare directories
+        # Resolve the project dir before changing into the scratch base.
+        project_dir="$(cd "${GITHUB_WORKSPACE}/${PROJECT_PATH}" && pwd)"
         cd "$BASE_DIR"
         # Move our repository
         mkdir -p cache cover log src/skins src/extensions
-        sudo cp -r "${GITHUB_WORKSPACE}" "src/${TYPE}s/${EXTENSION_NAME}"
+        sudo cp -r "$project_dir" "src/${TYPE}s/${EXTENSION_NAME}"
         chmod 777 src cache cover log
         # https://github.com/femiwiki/.github/issues/3
         sudo chown -R nobody:nogroup src cache


### PR DESCRIPTION
## What

Adds a `project-path` input naming the directory of the extension/skin under test, relative to the workspace (default `.`). This lifts the constraint that forced the end-to-end test to reference the action as `uses: ./_action`.

## Why

The action assumed the **workspace root** is the project under test: it reads `extension.json`/`skin.json` there and copies the whole workspace into `src/<type>s/<name>`. That made `uses: ./` impossible whenever a real project also needed the root, because the action code and the project both wanted to occupy the workspace root (hence the earlier `_action` workaround in the test workflow).

Named `project-path` rather than `path` to avoid confusion with `actions/checkout`'s `path` input, which appears right next to it in the same workflow.

## How

`project-path` (default `.`) is threaded through every project-root-dependent spot:
- project detection (`setup`)
- dependency resolution (`deps`)
- the phan `composer install`
- the MediaWiki cache key (`hashFiles`)
- the source copy in "Prepare directories"

Default `.` preserves existing behaviour exactly. With `project-path` set, the action can sit at the workspace root for `uses: ./` while the project is checked out into a subdirectory.

The end-to-end test now uses this: the action is `uses: ./` and BoilerPlate is checked out into `project/`, dropping the `_action` indirection (and its incidental copy of the action repo into `src/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)