### PR TITLE
fix: modernize the coverage stage to the quibble-coverage image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,3 +28,33 @@ jobs:
           mediawiki-version: REL1_45
           project-path: project
           upload-logs: true
+
+  coverage:
+    name: coverage on BoilerPlate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      # Coverage requires the master MediaWiki branch (that is where MediaWiki's
+      # coverage tooling lives), so test BoilerPlate's master branch against it.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: wikimedia/mediawiki-extensions-BoilerPlate
+          ref: master
+          path: project
+          persist-credentials: false
+      - id: quibble
+        uses: ./
+        with:
+          stage: coverage
+          mediawiki-version: master
+          project-path: project
+      # The coverage stage was pinned to the discontinued php74 image and so could
+      # never run; this asserts it now produces a report with quibble-coverage.
+      - name: Assert a coverage report was produced
+        env:
+          COVER_DIR: ${{ steps.quibble.outputs.coverage }}
+        run: |
+          ls -la "$COVER_DIR"
+          test -n "$(ls -A "$COVER_DIR" 2>/dev/null)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,8 +50,7 @@ jobs:
           stage: coverage
           mediawiki-version: master
           project-path: project
-      # The coverage stage was pinned to the discontinued php74 image and so could
-      # never run; this asserts it now produces a report with quibble-coverage.
+      # Assert the coverage stage produced a report (the cover dir is non-empty).
       - name: Assert a coverage report was produced
         env:
           COVER_DIR: ${{ steps.quibble.outputs.coverage }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ one of the two extra modes this action adds:
   `selenium`, `qunit`);
 - `phan` runs [Phan] static analysis instead of Quibble;
 - `coverage` runs PHPUnit code coverage and exposes the report through the
-  `coverage` output. It only runs on the `master` MediaWiki branch.
+  `coverage` output. It requires `mediawiki-version: master`, because
+  MediaWiki's coverage tooling (`tests/phpunit/generatePHPUnitConfig.php`)
+  currently lives only in the master branch; on other branches it is skipped.
 
 [Quibble stages documentation]: https://doc.wikimedia.org/quibble/usage.html#stages
 
@@ -125,20 +127,20 @@ the project under test out into a subdirectory and point `project-path` at it:
 
 Every stage runs in an official Wikimedia image, pulled as
 `<docker-registry>/<docker-org>/<image>:<tag>`. By default the `<image>` is
-derived from `php-version` (and `debian` for Quibble and coverage), so you
-usually only set those two knobs. Any image can also be pinned explicitly with
-its `*-docker-image` input, which takes precedence over the derivation.
+derived from `php-version` (and `debian` for Quibble), so you usually only set
+those two knobs. Any image can also be pinned explicitly with its
+`*-docker-image` input, which takes precedence over the derivation.
 
-| Stage | Derived image | Override input |
+| Stage | Image | Override input |
 | --- | --- | --- |
 | Quibble (`all` and individual stages) | `quibble-<debian>-php<version>` | `quibble-docker-image` |
-| `coverage` | `quibble-<debian>-php<version>-coverage` | `coverage-docker-image` |
+| `coverage` | `quibble-coverage` | `coverage-docker-image` |
 | `phan` | `mediawiki-phan-php<version>` | `phan-docker-image` |
 
 For example, `debian: buster` with `php-version: '8.1'` derives
-`quibble-buster-php81` and `mediawiki-phan-php81`. The coverage image is not
-derived by default; it falls back to its explicit `coverage-docker-image`
-default, because only a few coverage images are published.
+`quibble-buster-php81` and `mediawiki-phan-php81`. Coverage is not derived from
+`debian`/`php-version`: it uses the single `quibble-coverage` image (pcov-based,
+the one Wikimedia CI uses), which replaced the old per-PHP coverage images.
 
 `php-version` defaults to `8.4`, except for the `api-testing` stage, which
 defaults to `8.3`. That stage requires the wikidiff2 PHP extension, and the only
@@ -172,10 +174,10 @@ older PHP, such as when testing an older MediaWiki branch:
 | `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
-| `debian` | `bookworm` | Debian base for the Quibble and coverage images. |
+| `debian` | `bookworm` | Debian base for the Quibble image. |
 | `php-version` | `8.4` (`8.3` for `api-testing`) | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
-| `coverage-docker-image` | `quibble-buster-php74-coverage` | Override; `quibble-<debian>-php<version>-coverage` when empty. |
+| `coverage-docker-image` | `quibble-coverage` | Override for the single pcov-based coverage image. |
 | `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   docker-org:
     default: releng
   debian:
-    description: Debian base for the Quibble and coverage images.
+    description: Debian base for the Quibble image.
     default: bookworm
   quibble-docker-image:
     description: >-
@@ -16,10 +16,10 @@ inputs:
     default: ""
   coverage-docker-image:
     description: >-
-      Override for the coverage Docker image. When empty, it is derived as
-      `quibble-<debian>-php<version>-coverage`. Defaults to an explicit image
-      because few coverage images are published.
-    default: quibble-buster-php74-coverage
+      Override for the coverage Docker image. Defaults to `quibble-coverage`,
+      the single pcov-based image Wikimedia CI uses for PHPUnit coverage (it
+      replaced the old per-PHP `quibble-<debian>-php<version>-coverage` images).
+    default: quibble-coverage
   phan-docker-image:
     description: >-
       Override for the phan Docker image. When empty, it is derived from
@@ -27,8 +27,8 @@ inputs:
     default: ""
   php-version:
     description: >-
-      PHP version. Selects the `php<version>` part of the Quibble, coverage,
-      and phan images, and sets up this PHP on the host for the `phan` stage's
+      PHP version. Selects the `php<version>` part of the Quibble and phan
+      images, and sets up this PHP on the host for the `phan` stage's
       `composer install`. Available versions depend on the images published in
       the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
       When empty it is derived: `8.3` for the `api-testing` stage (the only
@@ -127,7 +127,9 @@ runs:
         # Resolve the Docker images from php-version and debian, unless overridden
         php="php${php_version//./}"
         QUIBBLE_DOCKER_IMAGE="${QUIBBLE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}}"
-        COVERAGE_DOCKER_IMAGE="${COVERAGE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}-coverage}"
+        # Coverage uses the single pcov-based quibble-coverage image (not a
+        # per-debian/php variant), matching current Wikimedia CI.
+        COVERAGE_DOCKER_IMAGE="${COVERAGE_IMAGE_OVERRIDE:-quibble-coverage}"
         PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-mediawiki-phan-${php}}"
         echo "quibble_image=${QUIBBLE_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
         echo "coverage_image=${COVERAGE_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
@@ -423,26 +425,28 @@ runs:
         COVERAGE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.coverage }}
       run: |
         # Coverage
-        if [ -d tests/phpunit ]; then
-          # MW1.35+ requires PHP7.3 but quibble-coverage is not.
-          if [ "${MEDIAWIKI_VERSION}" == 'master' ]; then
-            if [ "${TYPE}" == 'skin' ]; then
-              COMMAND=mwskin-phpunit-coverage
-            else
-              COMMAND=mwext-phpunit-coverage
-            fi
-            docker run \
-              --entrypoint quibble-with-supervisord \
-              -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \
-              -v "$(pwd)"/cache:/cache \
-              -v "$(pwd)"/src:/workspace/src \
-              -v "$(pwd)"/cover:/workspace/cover \
-              -v "$(pwd)"/log:/workspace/log \
-              "${DOCKER_REGISTRY}/${DOCKER_ORG}/${COVERAGE_DOCKER_IMAGE}:${COVERAGE_DOCKER_LATEST_TAG}" \
-              --skip-zuul \
-              --skip-deps \
-              -c "${COMMAND}"
+        # MediaWiki's coverage helper (tests/phpunit/generatePHPUnitConfig.php,
+        # invoked by mw{ext,skin}-phpunit-coverage) currently exists only on the
+        # master branch, so coverage requires mediawiki-version: master.
+        if [ "${MEDIAWIKI_VERSION}" != 'master' ]; then
+          echo "::warning::Skipping coverage: it requires mediawiki-version: master (MediaWiki's coverage tooling lives only in master)."
+        elif [ -d "src/${TYPE}s/${EXTENSION_NAME}/tests/phpunit" ]; then
+          if [ "${TYPE}" == 'skin' ]; then
+            COMMAND=mwskin-phpunit-coverage
+          else
+            COMMAND=mwext-phpunit-coverage
           fi
+          docker run \
+            --entrypoint quibble-with-supervisord \
+            -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \
+            -v "$(pwd)"/cache:/cache \
+            -v "$(pwd)"/src:/workspace/src \
+            -v "$(pwd)"/cover:/workspace/cover \
+            -v "$(pwd)"/log:/workspace/log \
+            "${DOCKER_REGISTRY}/${DOCKER_ORG}/${COVERAGE_DOCKER_IMAGE}:${COVERAGE_DOCKER_LATEST_TAG}" \
+            --skip-zuul \
+            --skip-deps \
+            -c "${COMMAND}"
         fi
 
     - if: inputs.stage != 'phan' && inputs.stage != 'coverage'

--- a/action.yml
+++ b/action.yml
@@ -369,7 +369,7 @@ runs:
         sudo chown -R nobody:nogroup src cache
         sudo chown $(id -u):$(id -g) src cache
 
-    - if: inputs.stage == 'phan' || inputs.stage == 'coverage'
+    - if: inputs.stage == 'phan'
       shell: bash
       working-directory: ${{ steps.setup.outputs.dir }}
       env:
@@ -423,6 +423,7 @@ runs:
         DOCKER_ORG: ${{ inputs.docker-org }}
         COVERAGE_DOCKER_IMAGE: ${{ steps.tags.outputs.coverage_image }}
         COVERAGE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.coverage }}
+        DEPENDENCIES: ${{ steps.deps.outputs.dependencies }}
       run: |
         # Coverage
         # MediaWiki's coverage helper (tests/phpunit/generatePHPUnitConfig.php,
@@ -436,6 +437,10 @@ runs:
           else
             COMMAND=mwext-phpunit-coverage
           fi
+          # Install dependencies inside the coverage image itself (no --skip-deps),
+          # so they resolve against that image's PHP. Resolving them in the separate
+          # quibble image, whose PHP can differ, pulls in packages the coverage image
+          # cannot run (e.g. Symfony 8 needs PHP 8.4 while quibble-coverage is 8.3).
           docker run \
             --entrypoint quibble-with-supervisord \
             -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \
@@ -445,8 +450,9 @@ runs:
             -v "$(pwd)"/log:/workspace/log \
             "${DOCKER_REGISTRY}/${DOCKER_ORG}/${COVERAGE_DOCKER_IMAGE}:${COVERAGE_DOCKER_LATEST_TAG}" \
             --skip-zuul \
-            --skip-deps \
-            -c "${COMMAND}"
+            --packages-source composer \
+            -c "${COMMAND}" \
+            $DEPENDENCIES
         fi
 
     - if: inputs.stage != 'phan' && inputs.stage != 'coverage'


### PR DESCRIPTION
## What

Makes the `coverage` stage actually run, by switching it to the modern `quibble-coverage` image and resolving its dependencies inside that image.

## Background

Wikimedia CI [moved coverage from xdebug to pcov](https://phabricator.wikimedia.org/T234020) and replaced the per-PHP `quibble-<debian>-php<version>-coverage` images with a single pcov-based **`quibble-coverage`** image. The old per-PHP variant was only ever published for **php74**, which cannot run modern MediaWiki. So coverage through this action was dead.

Source: [integration-config `jjb/mediawiki.yaml`](https://github.com/wikimedia/integration-config/blob/master/jjb/mediawiki.yaml) (`releng/quibble-coverage:1.18.2`); WMF's own master coverage is healthy (the [mediawiki-core report](https://doc.wikimedia.org/cover/) regenerates daily).

## Changes

- Default `coverage-docker-image` to `quibble-coverage` (no longer derived from `debian`/`php-version`).
- **Resolve coverage dependencies inside the coverage image** (drop `--skip-deps`, add `--packages-source composer`, and remove coverage from the shared quibble-image install step). Previously deps were resolved in the separate quibble image (php-version default `8.4`), which pulled in Symfony 8 (needs PHP 8.4.1), then ran in `quibble-coverage` (PHP 8.3) and fatally failed the composer platform check. A single image now does both, matching WMF.
- Fix the tests-directory probe: it checked `tests/phpunit` under the scratch base dir, not the extension's `src/<type>s/<name>/tests/phpunit`.
- Coverage requires `mediawiki-version: master` (MediaWiki's coverage helper `tests/phpunit/generatePHPUnitConfig.php` exists only on master, confirmed absent in REL1_43/44/45). On other branches the stage **skips with a clear warning**.
- Add a `coverage` job to the end-to-end test (BoilerPlate, master) asserting a report is produced.
- README and input-description updates.

## Verification

The `coverage on BoilerPlate` CI job runs end-to-end on master and asserts the `cover` directory holds a report (`clover.xml`, `dashboard.html`, ...). Green.

## Note

Coverage via this action only works against MediaWiki master, so an extension that ships on a stable branch must also be master-compatible to get coverage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)