### PR TITLE
ci: run lint and test on pull requests, push only on main

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -2,6 +2,8 @@
 name: Linter
 on:
   push:
+    branches: [main]
+  pull_request:
 permissions: {}
 jobs:
   yamllint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@
 name: Test
 on:
   push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
## What

Scopes `linter` and `test` to `push: branches: [main]` + `pull_request`, instead of `push` (all branches).

## Why

They ran on every push, which means they **never ran on fork PRs** (the push happens on the fork, not here) and ran **twice** on same-repo PRs. Now a PR — including from a fork — is checked once via `pull_request`, and `main` pushes still run. `zizmor` already does this; `semantic-pull-request` and `release-please` are unaffected.

This is why PR #36 (from a fork) initially showed no lint/test checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)