### PR TITLE
feat: derive PHP version from the MediaWiki branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,15 @@ For example, `debian: buster` with `php-version: '8.1'` derives
 `debian`/`php-version`: it uses the single `quibble-coverage` image (pcov-based,
 the one Wikimedia CI uses), which replaced the old per-PHP coverage images.
 
-`php-version` defaults to `8.4`, except for the `api-testing` stage, which
-defaults to `8.3`. That stage requires the wikidiff2 PHP extension, and the only
-published Quibble image that bundles it is `quibble-bookworm-php83`. Setting
-`php-version` (or `quibble-docker-image`) explicitly overrides this, but
-api-testing will fail on an image without wikidiff2.
+When `php-version` is empty it is derived from `mediawiki-version`, matching
+each MediaWiki branch's minimum PHP: `8.1` for REL1_43/REL1_44, `8.2` for
+REL1_45, `8.3` for REL1_46 and master, and `8.4` for anything else. MediaWiki
+releases only once or twice a year, so this table is cheap to keep current; a
+branch not listed falls back to `8.4`, so set `php-version` explicitly when
+testing older branches. The `api-testing` stage always uses `8.3`: it requires
+the wikidiff2 PHP extension, and the only published Quibble image that bundles
+it is `quibble-bookworm-php83`. Setting `php-version` (or `quibble-docker-image`)
+explicitly overrides all of this.
 
 Available bases and versions are whatever the
 [Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,
@@ -191,7 +195,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
 | `debian` | `bookworm` | Debian base for the Quibble image. |
-| `php-version` | `8.4` (`8.3` for `api-testing`) | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
+| `php-version` | derived from `mediawiki-version` (`8.3` for `api-testing`) | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-coverage` | Override for the single pcov-based coverage image. |
 | `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,10 @@ inputs:
       images, and sets up this PHP on the host for the `phan` stage's
       `composer install`. Available versions depend on the images published in
       the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
-      When empty it is derived: `8.3` for the `api-testing` stage (the only
-      image bundling wikidiff2, which that stage requires), `8.4` otherwise.
+      When empty it is derived from `mediawiki-version` to match that branch's
+      minimum PHP (see the README's "Docker images" section); the `api-testing`
+      stage always uses `8.3` (the only image bundling the wikidiff2 extension
+      it requires).
     default: ""
 
   project-path:
@@ -113,19 +115,27 @@ runs:
         DOCKER_ORG: ${{ inputs.docker-org }}
         DEBIAN: ${{ inputs.debian }}
         PHP_VERSION: ${{ inputs.php-version }}
+        MEDIAWIKI_VERSION: ${{ inputs.mediawiki-version }}
         QUIBBLE_IMAGE_OVERRIDE: ${{ inputs.quibble-docker-image }}
         COVERAGE_IMAGE_OVERRIDE: ${{ inputs.coverage-docker-image }}
         PHAN_IMAGE_OVERRIDE: ${{ inputs.phan-docker-image }}
         STAGE: ${{ inputs.stage }}
       run: |
-        # Resolve the effective PHP version, unless overridden.
-        # api-testing needs wikidiff2, bundled only in quibble-bookworm-php83.
+        # Effective PHP version: an explicit php-version wins; api-testing needs
+        # 8.3 (wikidiff2); otherwise derive it from the MediaWiki branch. See the
+        # README "Docker images" section for the table and rationale.
         if [ -n "${PHP_VERSION}" ]; then
           php_version="${PHP_VERSION}"
         elif [ "${STAGE}" == 'api-testing' ]; then
           php_version='8.3'
         else
-          php_version='8.4'
+          case "${MEDIAWIKI_VERSION}" in
+            REL1_43 | REL1_44) php_version='8.1' ;;
+            REL1_45) php_version='8.2' ;;
+            REL1_46) php_version='8.3' ;;
+            master) php_version='8.3' ;;
+            *) php_version='8.4' ;;
+          esac
         fi
         echo "php_version=${php_version}" >> "$GITHUB_OUTPUT"
         # Resolve the Docker images from php-version and debian, unless overridden


### PR DESCRIPTION
## What

When `php-version` is empty, derive it from `mediawiki-version` instead of always defaulting to `8.4`:

| MediaWiki | PHP |
| --- | --- |
| REL1_43, REL1_44 | 8.1 |
| REL1_45 | 8.2 |
| REL1_46, master | 8.3 |
| anything else | 8.4 |

`api-testing` still pins `8.3` (wikidiff2), and an explicit `php-version` / `quibble-docker-image` still overrides everything.

## Why

Each MediaWiki branch sets a minimum PHP in its `composer.json` (e.g. REL1_45 needs ≥8.2, REL1_46/master need ≥8.3), and an older branch may not support the newest PHP — so no single default fits all branches. Today consumers work around this with a per-version `quibble-docker-image` matrix. With this change the action picks the right PHP per branch, and consumers can drop that mapping.

Values are hardcoded rather than read from `composer.json` at runtime: MediaWiki releases only once or twice a year, so the table is cheap to keep current and avoids an extra fetch/parse on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)