### PR TITLE
feat: derive the Debian base from the MediaWiki branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ the wikidiff2 PHP extension, and the only published Quibble image that bundles
 it is `quibble-bookworm-php83`. Setting `php-version` (or `quibble-docker-image`)
 explicitly overrides all of this.
 
+The `debian` base is derived from `mediawiki-version` the same way: `buster`
+for REL1_43/REL1_44 (their Selenium tests need that image's older Chromium,
+which newer Chromium aborts on for those branches' test URLs) and `bookworm`
+otherwise; `api-testing` always uses `bookworm`. Set `debian` explicitly to
+override.
+
 Available bases and versions are whatever the
 [Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,
 so not every `debian` / `php-version` combination exists. For example, to pin an
@@ -194,7 +200,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
-| `debian` | `bookworm` | Debian base for the Quibble image. |
+| `debian` | derived from `mediawiki-version` | Debian base for the Quibble image (`buster` for REL1_43/REL1_44, else `bookworm`). See [Docker images](#docker-images). |
 | `php-version` | derived from `mediawiki-version` (`8.3` for `api-testing`) | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-coverage` | Override for the single pcov-based coverage image. |

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,11 @@ inputs:
   docker-org:
     default: releng
   debian:
-    description: Debian base for the Quibble image.
-    default: bookworm
+    description: >-
+      Debian base for the Quibble image. When empty it is derived from
+      `mediawiki-version`: `buster` for REL1_43/REL1_44 (their Selenium tests
+      need that image's older Chromium), `bookworm` otherwise.
+    default: ""
   quibble-docker-image:
     description: >-
       Override for the Quibble Docker image. When empty, it is derived as
@@ -138,9 +141,22 @@ runs:
           esac
         fi
         echo "php_version=${php_version}" >> "$GITHUB_OUTPUT"
+        # Effective Debian base: an explicit debian input wins; api-testing needs
+        # bookworm (its php8.3 image bundles wikidiff2); otherwise derive it from
+        # the MediaWiki branch. See the README "Docker images" section.
+        if [ -n "${DEBIAN}" ]; then
+          debian="${DEBIAN}"
+        elif [ "${STAGE}" == 'api-testing' ]; then
+          debian='bookworm'
+        else
+          case "${MEDIAWIKI_VERSION}" in
+            REL1_43 | REL1_44) debian='buster' ;;
+            *) debian='bookworm' ;;
+          esac
+        fi
         # Resolve the Docker images from php-version and debian, unless overridden
         php="php${php_version//./}"
-        QUIBBLE_DOCKER_IMAGE="${QUIBBLE_IMAGE_OVERRIDE:-quibble-${DEBIAN}-${php}}"
+        QUIBBLE_DOCKER_IMAGE="${QUIBBLE_IMAGE_OVERRIDE:-quibble-${debian}-${php}}"
         # Coverage uses the single pcov-based quibble-coverage image (not a
         # per-debian/php variant), matching current Wikimedia CI.
         COVERAGE_DOCKER_IMAGE="${COVERAGE_IMAGE_OVERRIDE:-quibble-coverage}"


### PR DESCRIPTION
## What

Derive `debian` from `mediawiki-version` when the input is empty, the same way `php-version` already is (#39):

| MediaWiki | Debian | (PHP) |
| --- | --- | --- |
| REL1_43, REL1_44 | `buster` | 8.1 |
| REL1_45 | `bookworm` | 8.2 |
| REL1_46, master | `bookworm` | 8.3 |
| `api-testing` (any) | `bookworm` | 8.3 |

An explicit `debian` input still overrides the derivation.

## Why

REL1_43/REL1_44's Selenium tests pass on the `buster` image but fail on `bookworm`: the newer Chromium there aborts (`net::ERR_ABORTED`) on those branches' double-slash test URLs. Pinning those branches to `buster` keeps them green.

Together with #39 (PHP derivation), consumers can drop their per-version image matrix entirely and let the action pick a working image per branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)