### PR TITLE
feat: annotate phan findings on the changed lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ for. It can also run [Phan] static analysis and PHPUnit code coverage.
 [Quibble]: https://doc.wikimedia.org/quibble/
 [Quibble Docker images]: https://docker-registry.wikimedia.org/
 [Phan]: https://github.com/phan/phan
+[cs2pr]: https://github.com/staabm/annotate-pull-request-from-checkstyle
 
 ## How it works
 
@@ -58,7 +59,13 @@ one of the two extra modes this action adds:
 
 - any stage from the [Quibble stages documentation] (for example `phpunit`,
   `selenium`, `qunit`);
-- `phan` runs [Phan] static analysis instead of Quibble;
+- `phan` runs [Phan] static analysis instead of Quibble, and reports each issue
+  as an inline annotation on the offending line in the pull request. How that
+  is produced depends on the project's phan version: **phan >= 5.5** has a
+  native `--output-mode=github` (used directly, no extra tooling), while
+  **older phan** emits `--output-mode=checkstyle` which is piped through
+  [cs2pr] for the same annotations. The version is detected from the project's
+  `phan/phan` entry, so either way works with no configuration;
 - `coverage` runs PHPUnit code coverage and exposes the report through the
   `coverage` output. It requires `mediawiki-version: master`, because
   MediaWiki's coverage tooling (`tests/phpunit/generatePHPUnitConfig.php`)

--- a/action.yml
+++ b/action.yml
@@ -416,12 +416,38 @@ runs:
         PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
         PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
       run: |
-        # Phan
-        docker run \
-          -e "THING_SUBNAME=${TYPE}s/${EXTENSION_NAME}" \
-          -v "$(pwd)"/src:/mediawiki \
-          "${DOCKER_REGISTRY}/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}:${PHAN_DOCKER_LATEST_TAG}" \
-          --color
+        # Phan, reported as inline PR annotations on the offending lines. phan
+        # >= 5.5 has a native `github` output mode (no extra tooling); older
+        # phan emits checkstyle, which cs2pr converts into the same annotations.
+        # Phan runs with `-d .`, so the paths are relative to the project root
+        # and resolve against the consumer's checkout.
+        image="${DOCKER_REGISTRY}/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}:${PHAN_DOCKER_LATEST_TAG}"
+        installed="src/${TYPE}s/${EXTENSION_NAME}/vendor/composer/installed.json"
+        phan_version="$(jq -r '(.packages // .)[] | select(.name == "phan/phan") | .version | ltrimstr("v")' "$installed" 2>/dev/null || true)"
+        if [ -n "$phan_version" ] && printf '%s\n5.5.0\n' "$phan_version" | sort -V | head -n1 | grep -qx '5.5.0'; then
+          # phan >= 5.5: native GitHub annotations.
+          docker run \
+            -e "THING_SUBNAME=${TYPE}s/${EXTENSION_NAME}" \
+            -v "$(pwd)"/src:/mediawiki \
+            "$image" \
+            --output-mode github
+        else
+          # phan < 5.5 (or undetected): annotate the checkstyle report with
+          # cs2pr, installed via composer (its documented distribution) into an
+          # isolated COMPOSER_HOME so it cannot clash with anything else on the
+          # runner.
+          status=0
+          docker run \
+            -e "THING_SUBNAME=${TYPE}s/${EXTENSION_NAME}" \
+            -v "$(pwd)"/src:/mediawiki \
+            "$image" \
+            --output-mode checkstyle > phan-checkstyle.xml || status=$?
+          export COMPOSER_HOME="$(pwd)/.cs2pr-composer"
+          composer global require --no-interaction --quiet \
+            staabm/annotate-pull-request-from-checkstyle:1.8.7
+          "$(composer global config bin-dir --absolute)/cs2pr" phan-checkstyle.xml || true
+          exit "$status"
+        fi
 
     - if: inputs.stage == 'coverage'
       shell: bash


### PR DESCRIPTION
## What

Report each phan issue as an inline annotation on the offending line in the PR, instead of burying it in the job log.

The mechanism adapts to the project's phan version (detected from its `installed.json`):

| phan version | how |
| --- | --- |
| **>= 5.5** | native `--output-mode=github` — no extra tooling |
| **< 5.5** | `--output-mode=checkstyle` piped through [cs2pr] (pinned 1.8.7) |

Either way needs no configuration, and older phan keeps working (no hard version bump required).

## Why

Phan paths come out relative to the project root (`-d .`), so they resolve against the consumer's checkout. Newer phan gets the zero-dependency native path; older phan still gets the same annotations via the maintained cs2pr tool.

## Notes

- quibble-action's own CI has no `phan` stage, so this is validated downstream (FemiwikiSkin).
- phpcs annotations are a separate follow-up (phpcs has no native GitHub output; needs checkstyle + cs2pr too).

[cs2pr]: https://github.com/staabm/annotate-pull-request-from-checkstyle

🤖 Generated with [Claude Code](https://claude.com/claude-code)