### PR TITLE
ci: test the phan stage on BoilerPlate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,25 @@ jobs:
           project-path: project
           upload-logs: true
 
+  phan:
+    name: phan on BoilerPlate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: wikimedia/mediawiki-extensions-BoilerPlate
+          ref: REL1_45
+          path: project
+          persist-credentials: false
+      - uses: ./
+        with:
+          stage: phan
+          mediawiki-version: REL1_45
+          project-path: project
+
   coverage:
     name: coverage on BoilerPlate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a `phan` job to the action's own CI, running the `phan` stage against the BoilerPlate fixture (REL1_45), mirroring the existing `phpunit-unit` job.

## Why

The `phan` stage currently has no coverage in this repo's CI, so changes to it are only exercised downstream. Adding this job means the phan code path runs here — groundwork for validating the upcoming inline-annotation support (#41) directly in this repo.

BoilerPlate is phan-clean, so the job is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)