### PR TITLE
feat: annotate phpcs findings on the changed lines

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,25 @@ jobs:
           mediawiki-version: REL1_45
           project-path: project
 
+  composer-test:
+    name: composer-test on BoilerPlate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: wikimedia/mediawiki-extensions-BoilerPlate
+          ref: REL1_45
+          path: project
+          persist-credentials: false
+      - uses: ./
+        with:
+          stage: composer-test
+          mediawiki-version: REL1_45
+          project-path: project
+
   coverage:
     name: coverage on BoilerPlate
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -506,17 +506,34 @@ runs:
         DEPENDENCIES: ${{ steps.deps.outputs.dependencies }}
       run: |
         # Quibble
+        image="${DOCKER_REGISTRY}/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}:${QUIBBLE_DOCKER_LATEST_TAG}"
+        status=0
         docker run \
           --entrypoint quibble-with-supervisord \
           -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \
           -v "$(pwd)"/cache:/cache \
           -v "$(pwd)"/src:/workspace/src \
           -v "$(pwd)"/log:/workspace/log \
-          "${DOCKER_REGISTRY}/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}:${QUIBBLE_DOCKER_LATEST_TAG}" \
+          "$image" \
           --skip-zuul \
           --packages-source composer \
           --run "${STAGE}" \
-          $DEPENDENCIES
+          $DEPENDENCIES || status=$?
+        # composer-test: surface phpcs findings as inline annotations. phpcs has
+        # no GitHub output mode, so re-run it with a checkstyle report and pipe
+        # that through cs2pr. This runs in the same image (it has PHP and
+        # composer) and reuses the vendor Quibble just installed in the mounted
+        # src, so nothing is reinstalled. cs2pr itself is installed with composer
+        # into an isolated COMPOSER_HOME.
+        if [ "${STAGE}" = 'composer-test' ]; then
+          docker run \
+            --entrypoint bash \
+            -e "PROJECT_DIR=/workspace/src/${TYPE}s/${EXTENSION_NAME}" \
+            -v "$(pwd)"/src:/workspace/src \
+            "$image" \
+            -c 'cd "$PROJECT_DIR" && export COMPOSER_HOME=/tmp/cs2pr-home && composer global require --no-interaction --quiet staabm/annotate-pull-request-from-checkstyle:1.8.7 && vendor/bin/phpcs --report=checkstyle -q | "$(composer global config bin-dir --absolute)/cs2pr"' || true
+        fi
+        exit "$status"
 
     - name: Make Quibble logs readable
       if: always() && inputs.upload-logs == 'true'


### PR DESCRIPTION
## What

Surface phpcs findings from the `composer-test` stage as inline annotations on the offending lines in the PR.

## How

phpcs runs inside Quibble's `composer test` and has no GitHub output mode, so after the Quibble run the action re-runs phpcs with a checkstyle report and pipes it through [cs2pr]:

- it runs in the **same Quibble image** (which already has PHP + composer) and **reuses the vendor Quibble just installed** in the mounted `src`, so nothing is reinstalled;
- cs2pr is installed with composer into an isolated `COMPOSER_HOME` (no ad-hoc download), matching the phan-stage approach (#41).

Adds a `composer-test on BoilerPlate` job to the action's own CI to exercise this path.

## Verified

On a fork PR with a deliberate phpcs violation (space indentation), the annotations landed on the exact lines:

```
includes/PhpcsProbe.php:6 [failure] Tabs must be used to indent lines; spaces are not allowed
includes/PhpcsProbe.php:7 …
includes/PhpcsProbe.php:8 …
```

## Caveat

phpcs results are MediaWiki-version-independent, so if a consumer runs `composer-test` across a version matrix the same annotations are emitted per job. Run `composer-test` on a single version to avoid duplicates.

[cs2pr]: https://github.com/staabm/annotate-pull-request-from-checkstyle

🤖 Generated with [Claude Code](https://claude.com/claude-code)