### PR TITLE
feat: run phan in the Quibble image instead of the unmaintained phan image

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,28 +158,46 @@ those two knobs. Any image can also be pinned explicitly with its
 | --- | --- | --- |
 | Quibble (`all` and individual stages) | `quibble-<debian>-php<version>` | `quibble-docker-image` |
 | `coverage` | `quibble-coverage` | `coverage-docker-image` |
-| `phan` | `mediawiki-phan-php<version>` | `phan-docker-image` |
+| `phan` | `quibble-bookworm-php<version>` | `phan-docker-image` |
 
-For example, `debian: buster` with `php-version: '8.1'` derives
-`quibble-buster-php81` and `mediawiki-phan-php81`. Coverage is not derived from
-`debian`/`php-version`: it uses the single `quibble-coverage` image (pcov-based,
-the one Wikimedia CI uses), which replaced the old per-PHP coverage images.
+`coverage` is not derived from `debian`/`php-version`: it uses the single
+`quibble-coverage` image (pcov-based, the one Wikimedia CI uses), which replaced
+the old per-PHP coverage images.
 
-When `php-version` is empty it is derived from `mediawiki-version`, matching
-each MediaWiki branch's minimum PHP: `8.1` for REL1_43/REL1_44, `8.2` for
-REL1_45, `8.3` for REL1_46 and master, and `8.4` for anything else. MediaWiki
-releases only once or twice a year, so this table is cheap to keep current; a
-branch not listed falls back to `8.4`, so set `php-version` explicitly when
-testing older branches. The `api-testing` stage always uses `8.3`: it requires
-the wikidiff2 PHP extension, and the only published Quibble image that bundles
-it is `quibble-bookworm-php83`. Setting `php-version` (or `quibble-docker-image`)
-explicitly overrides all of this.
+**`phan` runs in the Quibble image, not a phan-specific one.** Wikimedia stopped
+rebuilding the standalone `mediawiki-phan-php<version>` images in 2025-07; they
+are frozen at php-ast 1.1.2 and cannot run phan >= 6 (current
+`mediawiki-phan-config`), which needs php-ast 1.1.3+. The Quibble images are
+rebuilt continuously and ship a current php-ast, so phan now runs there
+(`--entrypoint bash … vendor/bin/phan`). phan does no browser work, so it always
+uses the `bookworm` base.
 
-The `debian` base is derived from `mediawiki-version` the same way: `buster`
-for REL1_43/REL1_44 (their Selenium tests need that image's older Chromium,
-which newer Chromium aborts on for those branches' test URLs) and `bookworm`
-otherwise; `api-testing` always uses `bookworm`. Set `debian` explicitly to
-override.
+### PHP version
+
+When `php-version` is empty it is derived from `mediawiki-version`, with two
+policies:
+
+- **Most stages** use each branch's **minimum** PHP, to test the floor: `8.1`
+  for REL1_43/REL1_44, `8.2` for REL1_45, `8.3` for REL1_46 and master, `8.4`
+  otherwise.
+- **`phan`** uses the **newest non-EOL** PHP each branch supports: `8.3` for
+  REL1_43/REL1_44, `8.4` for REL1_45/REL1_46 and master, `8.4` otherwise. phan
+  >= 6 needs PHP 8.2+, and newer PHP keeps us on the maintained images; phan is
+  static analysis, so a branch's runtime PHP support does not constrain it. If a
+  still-supported MediaWiki branch supported only EOL PHP, phan would fall back
+  to the newest of those.
+- **`api-testing`** always uses `8.3`: it needs the wikidiff2 PHP extension, and
+  the only published image bundling it is `quibble-bookworm-php83`.
+
+MediaWiki releases only once or twice a year, so these tables are cheap to keep
+current; a branch not listed falls back to `8.4`. Set `php-version` explicitly
+to override.
+
+The `debian` base is also derived from `mediawiki-version`: `buster` for
+REL1_43/REL1_44 (their Selenium tests need that image's older Chromium, which
+newer Chromium aborts on for those branches' test URLs) and `bookworm`
+otherwise. The `phan` and `api-testing` stages always use `bookworm`. Set
+`debian` explicitly to override.
 
 Available bases and versions are whatever the
 [Wikimedia Docker registry](https://docker-registry.wikimedia.org/) publishes,
@@ -207,11 +225,11 @@ older PHP, such as when testing an older MediaWiki branch:
 | `log-artifact-name` | `quibble-logs` | Name for the uploaded Quibble logs artifact. |
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
-| `debian` | derived from `mediawiki-version` | Debian base for the Quibble image (`buster` for REL1_43/REL1_44, else `bookworm`). See [Docker images](#docker-images). |
-| `php-version` | derived from `mediawiki-version` (`8.3` for `api-testing`) | PHP version. Selects the `php<version>` part of every image, and the host PHP for the `phan` stage. See [Docker images](#docker-images). |
+| `debian` | derived | Debian base for the Quibble image (`bookworm`, or `buster` for REL1_43/REL1_44 non-phan stages). See [Docker images](#docker-images). |
+| `php-version` | derived | PHP version for the images and the host. Branch minimum for most stages, newest non-EOL for `phan`. See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-coverage` | Override for the single pcov-based coverage image. |
-| `phan-docker-image` | (derived) | Override; `mediawiki-phan-php<version>` when empty. |
+| `phan-docker-image` | (derived) | Override for the `phan` image; the Quibble image (`quibble-bookworm-php<version>`) when empty. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,7 @@ inputs:
   docker-org:
     default: releng
   debian:
-    description: >-
-      Debian base for the Quibble image. When empty it is derived from
-      `mediawiki-version`: `buster` for REL1_43/REL1_44 (their Selenium tests
-      need that image's older Chromium), `bookworm` otherwise.
+    description: Debian base for the Quibble image. Derived from the stage and MediaWiki branch when empty; see the README "Docker images" section.
     default: ""
   quibble-docker-image:
     description: >-
@@ -24,20 +21,10 @@ inputs:
       replaced the old per-PHP `quibble-<debian>-php<version>-coverage` images).
     default: quibble-coverage
   phan-docker-image:
-    description: >-
-      Override for the phan Docker image. When empty, it is derived from
-      `php-version` as `mediawiki-phan-php<version>`.
+    description: Override for the image the `phan` stage runs in. Defaults to the Quibble image; see the README "Docker images" section.
     default: ""
   php-version:
-    description: >-
-      PHP version. Selects the `php<version>` part of the Quibble and phan
-      images, and sets up this PHP on the host for the `phan` stage's
-      `composer install`. Available versions depend on the images published in
-      the Wikimedia Docker registry (https://docker-registry.wikimedia.org/).
-      When empty it is derived from `mediawiki-version` to match that branch's
-      minimum PHP (see the README's "Docker images" section); the `api-testing`
-      stage always uses `8.3` (the only image bundling the wikidiff2 extension
-      it requires).
+    description: PHP version for the images and the host. Derived from the stage and MediaWiki branch when empty; see the README "Docker images" section.
     default: ""
 
   project-path:
@@ -124,13 +111,17 @@ runs:
         PHAN_IMAGE_OVERRIDE: ${{ inputs.phan-docker-image }}
         STAGE: ${{ inputs.stage }}
       run: |
-        # Effective PHP version: an explicit php-version wins; api-testing needs
-        # 8.3 (wikidiff2); otherwise derive it from the MediaWiki branch. See the
-        # README "Docker images" section for the table and rationale.
         if [ -n "${PHP_VERSION}" ]; then
           php_version="${PHP_VERSION}"
         elif [ "${STAGE}" == 'api-testing' ]; then
           php_version='8.3'
+        elif [ "${STAGE}" == 'phan' ]; then
+          case "${MEDIAWIKI_VERSION}" in
+            REL1_43 | REL1_44) php_version='8.3' ;;
+            REL1_45 | REL1_46) php_version='8.4' ;;
+            master) php_version='8.4' ;;
+            *) php_version='8.4' ;;
+          esac
         else
           case "${MEDIAWIKI_VERSION}" in
             REL1_43 | REL1_44) php_version='8.1' ;;
@@ -141,12 +132,9 @@ runs:
           esac
         fi
         echo "php_version=${php_version}" >> "$GITHUB_OUTPUT"
-        # Effective Debian base: an explicit debian input wins; api-testing needs
-        # bookworm (its php8.3 image bundles wikidiff2); otherwise derive it from
-        # the MediaWiki branch. See the README "Docker images" section.
         if [ -n "${DEBIAN}" ]; then
           debian="${DEBIAN}"
-        elif [ "${STAGE}" == 'api-testing' ]; then
+        elif [ "${STAGE}" == 'api-testing' ] || [ "${STAGE}" == 'phan' ]; then
           debian='bookworm'
         else
           case "${MEDIAWIKI_VERSION}" in
@@ -154,18 +142,13 @@ runs:
             *) debian='bookworm' ;;
           esac
         fi
-        # Resolve the Docker images from php-version and debian, unless overridden
         php="php${php_version//./}"
         QUIBBLE_DOCKER_IMAGE="${QUIBBLE_IMAGE_OVERRIDE:-quibble-${debian}-${php}}"
-        # Coverage uses the single pcov-based quibble-coverage image (not a
-        # per-debian/php variant), matching current Wikimedia CI.
         COVERAGE_DOCKER_IMAGE="${COVERAGE_IMAGE_OVERRIDE:-quibble-coverage}"
-        PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-mediawiki-phan-${php}}"
+        PHAN_DOCKER_IMAGE="${PHAN_IMAGE_OVERRIDE:-${QUIBBLE_DOCKER_IMAGE}}"
         echo "quibble_image=${QUIBBLE_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
         echo "coverage_image=${COVERAGE_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
         echo "phan_image=${PHAN_DOCKER_IMAGE}" >> "$GITHUB_OUTPUT"
-        # Get the latest docker tag
-        # Ref: https://github.com/thcipriani/dockerregistry
         QUIBBLE_DOCKER_LATEST_TAG="$(curl -sL "https://${DOCKER_REGISTRY}/v2/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}/tags/list" |
           python3 -c 'import json;print("\n".join(json.loads(input())["tags"]))' |
           grep -v latest | sort -Vr | head -1)"
@@ -227,13 +210,6 @@ runs:
         path: ${{ steps.setup.outputs.dir }}/docker-images/${{ steps.tags.outputs.coverage_image }}
         key: ${{ steps.tags.outputs.coverage_image }}:${{ steps.tags.outputs.coverage }}-${{ inputs.cache-key }}
 
-    - name: Cache phan docker image
-      if: inputs.stage == 'phan'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ${{ steps.setup.outputs.dir }}/docker-images/${{ steps.tags.outputs.phan_image }}
-        key: ${{ steps.tags.outputs.phan_image }}:${{ steps.tags.outputs.phan }}-${{ inputs.cache-key }}
-
     - if: inputs.stage == 'coverage'
       shell: bash
       env:
@@ -248,22 +224,6 @@ runs:
           docker load -i "${BASE_DIR}"/docker-images/"${COVERAGE_DOCKER_IMAGE}"
         else
           docker pull "${DOCKER_REGISTRY}/${DOCKER_ORG}/${COVERAGE_DOCKER_IMAGE}:${COVERAGE_DOCKER_LATEST_TAG}"
-        fi
-
-    - if: inputs.stage == 'phan'
-      shell: bash
-      env:
-        BASE_DIR: ${{ steps.setup.outputs.dir }}
-        PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
-        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-        DOCKER_ORG: ${{ inputs.docker-org }}
-        PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
-      run: |
-        # Load or pull phan docker image
-        if [ -f "${BASE_DIR}"/docker-images/"${PHAN_DOCKER_IMAGE}" ]; then
-          docker load -i "${BASE_DIR}"/docker-images/"${PHAN_DOCKER_IMAGE}"
-        else
-          docker pull "${DOCKER_REGISTRY}/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}:${PHAN_DOCKER_LATEST_TAG}"
         fi
 
     - name: Cache MediaWiki installation
@@ -416,32 +376,24 @@ runs:
         PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
         PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
       run: |
-        # Phan, reported as inline PR annotations on the offending lines. phan
-        # >= 5.5 has a native `github` output mode (no extra tooling); older
-        # phan emits checkstyle, which cs2pr converts into the same annotations.
-        # Phan runs with `-d .`, so the paths are relative to the project root
-        # and resolve against the consumer's checkout.
         image="${DOCKER_REGISTRY}/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}:${PHAN_DOCKER_LATEST_TAG}"
+        docker image inspect "$image" >/dev/null 2>&1 || docker pull "$image"
+        project="/workspace/src/${TYPE}s/${EXTENSION_NAME}"
         installed="src/${TYPE}s/${EXTENSION_NAME}/vendor/composer/installed.json"
         phan_version="$(jq -r '(.packages // .)[] | select(.name == "phan/phan") | .version | ltrimstr("v")' "$installed" 2>/dev/null || true)"
+        run_phan() {
+          docker run \
+            -e HOME=/tmp \
+            -v "$(pwd)"/src:/workspace/src \
+            --entrypoint bash \
+            "$image" \
+            -c "cd '$project' && vendor/bin/phan -d . --long-progress-bar --require-config-exists $1"
+        }
         if [ -n "$phan_version" ] && printf '%s\n5.5.0\n' "$phan_version" | sort -V | head -n1 | grep -qx '5.5.0'; then
-          # phan >= 5.5: native GitHub annotations.
-          docker run \
-            -e "THING_SUBNAME=${TYPE}s/${EXTENSION_NAME}" \
-            -v "$(pwd)"/src:/mediawiki \
-            "$image" \
-            --output-mode github
+          run_phan "--output-mode github"
         else
-          # phan < 5.5 (or undetected): annotate the checkstyle report with
-          # cs2pr, installed via composer (its documented distribution) into an
-          # isolated COMPOSER_HOME so it cannot clash with anything else on the
-          # runner.
           status=0
-          docker run \
-            -e "THING_SUBNAME=${TYPE}s/${EXTENSION_NAME}" \
-            -v "$(pwd)"/src:/mediawiki \
-            "$image" \
-            --output-mode checkstyle > phan-checkstyle.xml || status=$?
+          run_phan "--output-mode checkstyle" > phan-checkstyle.xml || status=$?
           export COMPOSER_HOME="$(pwd)/.cs2pr-composer"
           composer global require --no-interaction --quiet \
             staabm/annotate-pull-request-from-checkstyle:1.8.7
@@ -563,10 +515,8 @@ runs:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_ORG: ${{ inputs.docker-org }}
         QUIBBLE_DOCKER_IMAGE: ${{ steps.tags.outputs.quibble_image }}
-        PHAN_DOCKER_IMAGE: ${{ steps.tags.outputs.phan_image }}
         COVERAGE_DOCKER_IMAGE: ${{ steps.tags.outputs.coverage_image }}
         QUIBBLE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.quibble }}
-        PHAN_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.phan }}
         COVERAGE_DOCKER_LATEST_TAG: ${{ steps.tags.outputs.coverage }}
         BASE_DIR: ${{ steps.setup.outputs.dir }}
       run: |
@@ -580,11 +530,7 @@ runs:
         rm "$(pwd)/docker-images/${QUIBBLE_DOCKER_IMAGE}" || true
         docker save -o "$(pwd)/docker-images/${QUIBBLE_DOCKER_IMAGE}" \
           "${DOCKER_REGISTRY}/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}:${QUIBBLE_DOCKER_LATEST_TAG}"
-        if [ -n "$PHAN_DOCKER_LATEST_TAG" ]; then
-          rm "$(pwd)/docker-images/${PHAN_DOCKER_IMAGE}" || true
-          docker save -o "$(pwd)/docker-images/${PHAN_DOCKER_IMAGE}" \
-            "${DOCKER_REGISTRY}/${DOCKER_ORG}/${PHAN_DOCKER_IMAGE}:${PHAN_DOCKER_LATEST_TAG}"
-        elif [ -n "$COVERAGE_DOCKER_LATEST_TAG" ]; then
+        if [ -n "$COVERAGE_DOCKER_LATEST_TAG" ]; then
           rm "$(pwd)/docker-images/${COVERAGE_DOCKER_IMAGE}" || true
           docker save -o "$(pwd)/docker-images/${COVERAGE_DOCKER_IMAGE}" \
             "${DOCKER_REGISTRY}/${DOCKER_ORG}/${COVERAGE_DOCKER_IMAGE}:${COVERAGE_DOCKER_LATEST_TAG}"


### PR DESCRIPTION
## Why

The `phan` stage pulled the standalone `mediawiki-phan-php<version>` images. Those have not been rebuilt since **2025-07** and are frozen at **php-ast 1.1.2**, so they cannot run **phan >= 6** (current `mediawiki-phan-config` 0.19+/0.20), which requires php-ast 1.1.3+. phan exits with `ERROR: Phan 6.x requires php-ast 1.1.3+ … Exiting without analyzing files.` before analyzing anything.

Wikimedia itself no longer relies on those images: extensions on `master` already pin `mediawiki-phan-config: 0.20.0`, and phan runs inside the **Quibble image**, which is rebuilt continuously (latest 2026-06-18) and ships a current php-ast.

Registry evidence:

| Image | Latest build | php-ast |
| --- | --- | --- |
| `mediawiki-phan-php83` / `php84` | 2025-07-23 (frozen) | 1.1.2 |
| `quibble-bookworm-php81…84` | 2026-06-18 | current |

## What

- Run phan inside the Quibble image (already pulled for the install step) via `--entrypoint bash … vendor/bin/phan`. Drop the dedicated phan-image cache/load/save steps.
- phan forces the `bookworm` base (it runs no browser, so the buster Chromium workaround is moot, and only the bookworm images are maintained).
- phan PHP = newest **non-EOL** PHP each MediaWiki branch supports (`8.3` for REL1_43/44, `8.4` for REL1_45/46/master). If a still-supported branch supported only EOL PHP, phan falls back to the newest of those. phan is static analysis, so a branch's runtime PHP support does not constrain it.
- `phan-docker-image` still overrides the image. Rationale moved from `action.yml` comments into the README.

## Validation

This PR's own CI runs the `phan on BoilerPlate` job, which exercises the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)