### PR TITLE
fix: Make Wikibase submodule URL fix branch-agnostic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -248,48 +248,27 @@ runs:
               git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://gerrit.wikimedia.org/r/${dep}" src/"$(echo $dep | cut -d'/' -f2,3)"
 
               cd src/"$(echo $dep | cut -d'/' -f2,3)"
+              # Repoint dead phabricator submodule URLs at their github
+              # mirrors. Idempotent: a no-op on branches that already use
+              # github (e.g. master), where a hardcoded patch failed to apply.
               # https://gerrit.wikimedia.org/r/q/I2037cd8bb5d568021472e048900649028b5dcc62
-              git apply << 'EOF'
-        diff --git a/.gitmodules b/.gitmodules
-        index df41c768af..e9926d6ddd 100644
-        --- a/.gitmodules
-        +++ b/.gitmodules
-        @@ -3,13 +3,13 @@
-         	url = https://gerrit.wikimedia.org/r/data-values/value-view
-         [submodule "view/lib/wikibase-serialization"]
-         	path = view/lib/wikibase-serialization
-        -	url = https://phabricator.wikimedia.org/source/wikibase-serialization.git
-        +	url = https://github.com/wmde/WikibaseSerializationJavaScript.git
-         [submodule "view/lib/wikibase-data-values"]
-         	path = view/lib/wikibase-data-values
-        -	url = https://phabricator.wikimedia.org/source/datavalues-javascript.git
-        +	url = https://github.com/wmde/DataValuesJavaScript.git
-         [submodule "view/lib/wikibase-data-model"]
-         	path = view/lib/wikibase-data-model
-        -	url = https://phabricator.wikimedia.org/source/wikibase-data-model.git
-        +	url = https://github.com/wmde/WikibaseDataModelJavaScript.git
-         [submodule "view/lib/wikibase-termbox"]
-         	path = view/lib/wikibase-termbox
-         	url = https://gerrit.wikimedia.org/r/wikibase/termbox
-        EOF
+              sed -i \
+                -e 's#https://phabricator.wikimedia.org/source/wikibase-serialization.git#https://github.com/wmde/WikibaseSerializationJavaScript.git#' \
+                -e 's#https://phabricator.wikimedia.org/source/datavalues-javascript.git#https://github.com/wmde/DataValuesJavaScript.git#' \
+                -e 's#https://phabricator.wikimedia.org/source/wikibase-data-model.git#https://github.com/wmde/WikibaseDataModelJavaScript.git#' \
+                .gitmodules
               git submodule update --init
               cd -
             elif [ "$dep" = 'mediawiki/extensions/WikibaseLexeme' ]; then
               git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://gerrit.wikimedia.org/r/${dep}" src/"$(echo $dep | cut -d'/' -f2,3)"
 
               cd src/"$(echo $dep | cut -d'/' -f2,3)"
+              # Repoint the dead phabricator submodule URL at its github
+              # mirror. Idempotent across branches; see the Wikibase note above.
               # https://gerrit.wikimedia.org/r/q/I2037cd8bb5d568021472e048900649028b5dcc62
-              git apply << 'EOF'
-        diff --git a/.gitmodules b/.gitmodules
-        index 51ab4cd..97dff70 100644
-        --- a/.gitmodules
-        +++ b/.gitmodules
-        @@ -1,3 +1,3 @@
-         [submodule "resources/special/new-lexeme"]
-         	path = resources/special/new-lexeme
-        -	url = https://phabricator.wikimedia.org/diffusion/NLSP/new-lexeme-special-page.git
-        +	url = https://github.com/wmde/new-lexeme-special-page.git
-        EOF
+              sed -i \
+                -e 's#https://phabricator.wikimedia.org/diffusion/NLSP/new-lexeme-special-page.git#https://github.com/wmde/new-lexeme-special-page.git#' \
+                .gitmodules
               git submodule update --init
               cd -
             else


### PR DESCRIPTION
The Wikibase / WikibaseLexeme dependency clones repoint their dead phabricator submodule URLs to github. That was done with a hardcoded `git apply` patch, which only matches the REL1_43-era `.gitmodules`. On **master** (upstream already moved off phabricator) the patch fails with `patch does not apply` and aborts the whole job, so **every master stage of a Wikibase-dependent extension goes red**.

Discovered while migrating UnifiedExtensionForFemiwiki to this action (femiwiki/UnifiedExtensionForFemiwiki#217): all 7 master jobs failed at `error: .gitmodules: patch does not apply`, while REL1_43 passed.

Replaces the patch with idempotent `sed -i` URL rewrites: they rewrite the phabricator URLs when present, and are a no-op otherwise, so dependency resolution works on every branch.