### PR TITLE
feat: Skip selenium stage when the project has no selenium tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -439,6 +439,15 @@ runs:
         # Quibble
         image="${DOCKER_REGISTRY}/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}:${QUIBBLE_DOCKER_LATEST_TAG}"
         status=0
+        # Quibble's selenium stage runs `npm run selenium-test` for every project
+        # that has it, dependencies included. When the project under test has no
+        # selenium-test script there is nothing of ours to run, and only the
+        # dependencies' (often flaky) suites would execute, so skip the stage.
+        if [ "${STAGE}" = 'selenium' ] && \
+          ! jq -e '.scripts["selenium-test"]' "src/${TYPE}s/${EXTENSION_NAME}/package.json" >/dev/null 2>&1; then
+          echo "No selenium-test script in ${EXTENSION_NAME}; skipping selenium (nothing of ours to run)."
+          exit 0
+        fi
         docker run \
           --entrypoint quibble-with-supervisord \
           -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \


### PR DESCRIPTION
Quibble's selenium stage runs `npm run selenium-test` for **every** project in its list, dependencies included (`quibble/commands.py` `BrowserTests` loops all projects; there is no flag to scope it to the project under test). So when the project under test has no `selenium-test` script, only the *dependencies'* suites run.

That is exactly what happens for UnifiedExtensionForFemiwiki: it has no browser tests, but depends on Wikibase, so `--run selenium` runs Wikibase's bundled `wikibase-termbox` selenium specs, which flakily time out. The selenium check is red forever for a repo that has nothing to test.

This skips the selenium stage when the project under test has no `selenium-test` npm script, there is nothing of ours to run. Projects that *do* have selenium tests (e.g. FemiwikiSkin) are unaffected and still run `--run selenium` as before.

Lets the extension's selenium check go green legitimately instead of relying on admin-merge overrides.