### PR TITLE
revert: skip selenium stage when the project has no selenium tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -439,15 +439,6 @@ runs:
         # Quibble
         image="${DOCKER_REGISTRY}/${DOCKER_ORG}/${QUIBBLE_DOCKER_IMAGE}:${QUIBBLE_DOCKER_LATEST_TAG}"
         status=0
-        # Quibble's selenium stage runs `npm run selenium-test` for every project
-        # that has it, dependencies included. When the project under test has no
-        # selenium-test script there is nothing of ours to run, and only the
-        # dependencies' (often flaky) suites would execute, so skip the stage.
-        if [ "${STAGE}" = 'selenium' ] && \
-          ! jq -e '.scripts["selenium-test"]' "src/${TYPE}s/${EXTENSION_NAME}/package.json" >/dev/null 2>&1; then
-          echo "No selenium-test script in ${EXTENSION_NAME}; skipping selenium (nothing of ours to run)."
-          exit 0
-        fi
         docker run \
           --entrypoint quibble-with-supervisord \
           -e "ZUUL_PROJECT=mediawiki/${TYPE}s/${EXTENSION_NAME}" \


### PR DESCRIPTION
Reverts #46. Skipping dependency selenium tests discards exactly the integration signal browser tests exist for, catching when a change breaks a *dependency* extension's behavior. We should keep running them; the real issue is the flaky/under-provisioned Wikibase termbox suite, which will be addressed separately.