### PR TITLE
fix: drop the phan-specific PHP version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,16 +178,12 @@ installed in the Quibble image first, then phan runs over them in
 When `php-version` is empty it is derived from `mediawiki-version`, with two
 policies:
 
-- **Most stages** use each branch's **minimum** PHP, to test the floor: `8.1`
-  for REL1_43/REL1_44, `8.2` for REL1_45, `8.3` for REL1_46 and master, `8.4`
-  otherwise.
-- **`phan`** uses the **newest non-EOL** PHP each branch supports: `8.3` for
-  REL1_43/REL1_44, `8.4` for REL1_45/REL1_46 and master, `8.4` otherwise. This
-  selects the Quibble image that installs phan's dependencies (phan itself runs
-  in `mediawiki-phan-testrun`); phan >= 6 needs PHP 8.2+, so the branch minimum
-  would be too old to resolve it. phan is static analysis, so a branch's runtime
-  PHP support does not constrain it. If a still-supported MediaWiki branch
-  supported only EOL PHP, phan would fall back to the newest of those.
+- **Most stages**, including `phan`, use each branch's **minimum** PHP, to test
+  the floor: `8.1` for REL1_43/REL1_44, `8.2` for REL1_45, `8.3` for REL1_46 and
+  master, `8.4` otherwise. For `phan` this only selects the Quibble image that
+  installs its dependencies (phan itself runs in `mediawiki-phan-testrun`); the
+  minimum already clears phan's floor (phan 6 needs PHP 8.1+, phan 5 less), so it
+  needs no higher version of its own.
 - **`api-testing`** always uses `8.3`: it needs the wikidiff2 PHP extension, and
   the only published image bundling it is `quibble-bookworm-php83`.
 
@@ -228,7 +224,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | `docker-registry` | `docker-registry.wikimedia.org` | Registry that hosts the images. |
 | `docker-org` | `releng` | Registry organization. |
 | `debian` | derived | Debian base for the Quibble image (`bookworm`, or `buster` for REL1_43/REL1_44 non-phan stages). See [Docker images](#docker-images). |
-| `php-version` | derived | PHP version for the images and the host. Branch minimum for most stages, newest non-EOL for `phan`. See [Docker images](#docker-images). |
+| `php-version` | derived | PHP version for the images and the host. Branch minimum (for `phan`, the image that installs its deps; phan runs in `mediawiki-phan-testrun`). See [Docker images](#docker-images). |
 | `quibble-docker-image` | (derived) | Override; `quibble-<debian>-php<version>` when empty. |
 | `coverage-docker-image` | `quibble-coverage` | Override for the single pcov-based coverage image. |
 | `phan-docker-image` | `mediawiki-phan-testrun` | Override for the `phan` run image; `mediawiki-phan-testrun` when empty. |

--- a/action.yml
+++ b/action.yml
@@ -115,13 +115,6 @@ runs:
           php_version="${PHP_VERSION}"
         elif [ "${STAGE}" == 'api-testing' ]; then
           php_version='8.3'
-        elif [ "${STAGE}" == 'phan' ]; then
-          case "${MEDIAWIKI_VERSION}" in
-            REL1_43 | REL1_44) php_version='8.3' ;;
-            REL1_45 | REL1_46) php_version='8.4' ;;
-            master) php_version='8.4' ;;
-            *) php_version='8.4' ;;
-          esac
         else
           case "${MEDIAWIKI_VERSION}" in
             REL1_43 | REL1_44) php_version='8.1' ;;


### PR DESCRIPTION
Follow-up to #49.

## Why

Since #49, the `phan` stage runs in the fixed `mediawiki-phan-testrun` image (PHP 8.3 + php-ast 1.1.3). The `php-version` output therefore only picks the Quibble image used to **install** phan's dependencies. The phan-specific "newest non-EOL" override bumped that to **8.4** for REL1_45+/master, so deps were installed on 8.4 while phan ran on testrun's **8.3** — a needless install/run skew.

The override's stated premise ("phan >= 6 needs PHP 8.2+") was wrong: phan 6.0.2 requires only `^8.1.0`, and phan 5 needs `^7.2`. Every branch minimum (8.1 / 8.2 / 8.3 / 8.3) already clears phan's floor, so the bump was never needed to install phan.

## Change

Drop the `elif [ "$STAGE" == 'phan' ]` block from the `php-version` derivation; phan now uses the branch minimum like other stages. phan still forces the `bookworm` base (it does no browser work). README updated.

Resulting phan install image (run image is always `mediawiki-phan-testrun`):

| branch | install image | install PHP vs run (8.3) |
| --- | --- | --- |
| REL1_43/44 | `quibble-bookworm-php81` | 8.1 ≤ 8.3 |
| REL1_45 | `quibble-bookworm-php82` | 8.2 ≤ 8.3 |
| REL1_46/master | `quibble-bookworm-php83` | **8.3 = 8.3** |

All four images exist and share the current Quibble tag (`1.18.2`). Installing on an equal-or-lower PHP than the run image is the safe direction (no chance of pulling a transitive dep that needs a newer PHP than testrun provides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)