### PR TITLE
fix: clone MediaWiki and dependencies from the GitHub mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ older PHP, such as when testing an older MediaWiki branch:
 | Name | Default | Description |
 | --- | --- | --- |
 | `mediawiki-version` | `REL1_45` | MediaWiki branch to test against, for example `master` or `REL1_43`. |
+| `git-source` | `github` | Where MediaWiki and the dependencies are cloned from: `github` (the official read-only mirrors, immune to Gerrit's CI rate limiting) or `gerrit` (gerrit.wikimedia.org). |
 | `stage` | `all` | Stage to run. Any Quibble stage, or `phan` / `coverage`. |
 | `project-path` | `.` | Path to the extension or skin under test, relative to the workspace. Set it when the action is checked out at the workspace root (so it can be used as `uses: ./`) and the project is in a subdirectory. See [Testing from the same repository](#testing-from-the-same-repository). |
 | `dependencies` | (none) | Whitespace/comma separated dependency extensions/skins. Takes priority over the `requires` clause and phan config. See [Defining dependencies](#defining-dependencies). |

--- a/action.yml
+++ b/action.yml
@@ -231,14 +231,17 @@ runs:
         MEDIAWIKI_VERSION: ${{ inputs.mediawiki-version }}
         DEPENDENCIES: ${{ steps.deps.outputs.dependencies }}
       run: |
-        # Download MediaWiki and extensions
+        # Download MediaWiki and extensions. Cloned from the official GitHub
+        # mirrors (github.com/wikimedia/*, same refs as Gerrit): Gerrit
+        # rate-limits the shared Actions runner IPs (HTTP 429), which made
+        # these clones fail intermittently.
         cd "$BASE_DIR"
         if [ ! -d src ]; then
-          git clone -b "${MEDIAWIKI_VERSION}" --depth 1 https://gerrit.wikimedia.org/r/mediawiki/core src
-          git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 https://gerrit.wikimedia.org/r/mediawiki/skins/Vector src/skins/Vector
+          git clone -b "${MEDIAWIKI_VERSION}" --depth 1 https://github.com/wikimedia/mediawiki src
+          git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 https://github.com/wikimedia/mediawiki-skins-Vector src/skins/Vector
           for dep in $DEPENDENCIES; do
             if [ "$dep" = 'mediawiki/extensions/Wikibase' ]; then
-              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://gerrit.wikimedia.org/r/${dep}" src/"$(echo $dep | cut -d'/' -f2,3)"
+              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://github.com/wikimedia/$(echo $dep | tr '/' '-')" src/"$(echo $dep | cut -d'/' -f2,3)"
 
               cd src/"$(echo $dep | cut -d'/' -f2,3)"
               # Repoint dead phabricator submodule URLs at their github
@@ -253,7 +256,7 @@ runs:
               git submodule update --init
               cd -
             elif [ "$dep" = 'mediawiki/extensions/WikibaseLexeme' ]; then
-              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://gerrit.wikimedia.org/r/${dep}" src/"$(echo $dep | cut -d'/' -f2,3)"
+              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://github.com/wikimedia/$(echo $dep | tr '/' '-')" src/"$(echo $dep | cut -d'/' -f2,3)"
 
               cd src/"$(echo $dep | cut -d'/' -f2,3)"
               # Repoint the dead phabricator submodule URL at its github
@@ -265,7 +268,7 @@ runs:
               git submodule update --init
               cd -
             else
-              git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 "https://gerrit.wikimedia.org/r/${dep}" src/"$(echo $dep | cut -d'/' -f2,3)"
+              git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 "https://github.com/wikimedia/$(echo $dep | tr '/' '-')" src/"$(echo $dep | cut -d'/' -f2,3)"
             fi
           done
         fi

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,13 @@ inputs:
     default: "."
   mediawiki-version:
     default: REL1_45
+  git-source:
+    description: >-
+      Where MediaWiki and the dependency extensions/skins are cloned from:
+      `github` for the official read-only mirrors (github.com/wikimedia/*), or
+      `gerrit` for gerrit.wikimedia.org. The mirrors carry the same branches
+      and are not subject to Gerrit's rate limiting of CI runners.
+    default: github
   stage:
     description: All stages listed at https://doc.wikimedia.org/quibble/usage.html#stages. `phan` and `coverage` also supported.
     default: all
@@ -230,18 +237,28 @@ runs:
         BASE_DIR: ${{ steps.setup.outputs.dir }}
         MEDIAWIKI_VERSION: ${{ inputs.mediawiki-version }}
         DEPENDENCIES: ${{ steps.deps.outputs.dependencies }}
+        GIT_SOURCE: ${{ inputs.git-source }}
       run: |
-        # Download MediaWiki and extensions. Cloned from the official GitHub
+        # Download MediaWiki and extensions. By default from the official GitHub
         # mirrors (github.com/wikimedia/*, same refs as Gerrit): Gerrit
         # rate-limits the shared Actions runner IPs (HTTP 429), which made
-        # these clones fail intermittently.
+        # these clones fail intermittently. `git-source: gerrit` clones from
+        # gerrit.wikimedia.org instead. A Gerrit path maps to a mirror name by
+        # replacing slashes with dashes; mediawiki/core is the mediawiki mirror.
+        if [ "${GIT_SOURCE}" = 'gerrit' ]; then
+          core_url='https://gerrit.wikimedia.org/r/mediawiki/core'
+          repo_url() { echo "https://gerrit.wikimedia.org/r/$1"; }
+        else
+          core_url='https://github.com/wikimedia/mediawiki'
+          repo_url() { echo "https://github.com/wikimedia/$(echo "$1" | tr '/' '-')"; }
+        fi
         cd "$BASE_DIR"
         if [ ! -d src ]; then
-          git clone -b "${MEDIAWIKI_VERSION}" --depth 1 https://github.com/wikimedia/mediawiki src
-          git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 https://github.com/wikimedia/mediawiki-skins-Vector src/skins/Vector
+          git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "$core_url" src
+          git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 "$(repo_url mediawiki/skins/Vector)" src/skins/Vector
           for dep in $DEPENDENCIES; do
             if [ "$dep" = 'mediawiki/extensions/Wikibase' ]; then
-              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://github.com/wikimedia/$(echo $dep | tr '/' '-')" src/"$(echo $dep | cut -d'/' -f2,3)"
+              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "$(repo_url "$dep")" src/"$(echo $dep | cut -d'/' -f2,3)"
 
               cd src/"$(echo $dep | cut -d'/' -f2,3)"
               # Repoint dead phabricator submodule URLs at their github
@@ -256,7 +273,7 @@ runs:
               git submodule update --init
               cd -
             elif [ "$dep" = 'mediawiki/extensions/WikibaseLexeme' ]; then
-              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "https://github.com/wikimedia/$(echo $dep | tr '/' '-')" src/"$(echo $dep | cut -d'/' -f2,3)"
+              git clone -b "${MEDIAWIKI_VERSION}" --depth 1 "$(repo_url "$dep")" src/"$(echo $dep | cut -d'/' -f2,3)"
 
               cd src/"$(echo $dep | cut -d'/' -f2,3)"
               # Repoint the dead phabricator submodule URL at its github
@@ -268,7 +285,7 @@ runs:
               git submodule update --init
               cd -
             else
-              git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 "https://github.com/wikimedia/$(echo $dep | tr '/' '-')" src/"$(echo $dep | cut -d'/' -f2,3)"
+              git clone --recurse-submodules -b "${MEDIAWIKI_VERSION}" --depth 1 "$(repo_url "$dep")" src/"$(echo $dep | cut -d'/' -f2,3)"
             fi
           done
         fi


### PR DESCRIPTION
## Why

Gerrit rate-limits the shared GitHub Actions runner IPs, so the MediaWiki core and dependency clones fail intermittently with **HTTP 429** (`error: RPC failed; HTTP 429` while `Cloning into 'src'`). Downstream this broke CI across repos for over an hour today, surviving multiple spaced retries (observed on chaotic-ground/SifterSearch PRs #33/#34: four rerun attempts across ~90 minutes, all 429).

## What

Clone from the official read-only **GitHub mirrors** instead (`github.com/wikimedia/*`, same branches and content); runner-to-GitHub traffic is not throttled this way.

- `mediawiki/core` → `wikimedia/mediawiki`
- Gerrit paths map to mirror names by replacing slashes with dashes: `mediawiki/extensions/Wikibase` → `wikimedia/mediawiki-extensions-Wikibase` (`tr '/' '-'`)
- The Wikibase/WikibaseLexeme submodule fixups are unchanged: the mirrors carry the same `.gitmodules`, and the phabricator-URL rewrites already pointed at GitHub.

Not breaking: no input or behaviour change beyond the clone source; treated as a `fix` for release-please.

## Verification

- `git ls-remote --heads` confirms `REL1_45` resolves on the mirrors for `mediawiki`, `mediawiki-skins-Vector`, `mediawiki-extensions-Wikibase`, and `mediawiki-extensions-BoilerPlate`.
- This repo's self-test workflow (`uses: ./` running phpunit-unit/phan/composer-test on BoilerPlate) exercises the new clone path end-to-end on this very PR.
- `yamllint` passes.

## Update: `git-source` input

Per review, the clone source is now selectable instead of hardcoded: a new `git-source` input takes `github` (default, the mirrors as above) or `gerrit` (the previous behaviour, cloning from gerrit.wikimedia.org). The Gerrit-path-to-mirror-name mapping lives in a small `repo_url` helper shared by both branches; documented in the README inputs table. Verified both branches produce the exact URLs (Gerrit URLs byte-identical to main's originals), and that Gerrit and the mirror serve the same `REL1_45` head SHA.


## Downstream test on a real consumer

Tested against chaotic-ground/SifterSearch#35, whose quibble jobs (phan, phpunit, npm-test) had been failing repeatedly with the Gerrit 429 (four spaced retries across ~90 minutes, all throttled):

- Temporarily pinned this PR's head there via a DO-NOT-MERGE commit: chaotic-ground/SifterSearch@3bb6d3e ("DO NOT MERGE: run quibble via femiwiki/quibble-action#53 (GitHub mirror clones)").
- The full Quibble matrix then passed on the first attempt: https://github.com/chaotic-ground/SifterSearch/actions/runs/28630732095
- The commit was reverted afterwards (chaotic-ground/SifterSearch@a9644cd); the pin bump proper will follow the release.
